### PR TITLE
travis: build github release builds (per platform) via a build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
 
     matrix:
         - JOB_TYPE=compile_and_basic_tests
+        - GOARCH=amd64 GOOS=linux
+        - GOARCH=amd64 GOOS=darwin
 
 before_install:
     - go get -u github.com/fzipp/gocyclo
@@ -50,14 +52,14 @@ script:
       fi
 
     # Insert build information into compiled binary using ldflags
-    - CGO_ENABLED=0 go build -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`"
+    - CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o $GITHUB_RELEASE_BINARY.$GOOS.$GOARCH -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`"
 
 deploy:
     # Push to github releases upon tagging.
     -
         provider: releases
         api_key: $GITHUB_RELEASE_TOKEN
-        file: $GITHUB_RELEASE_BINARY
+        file: $GITHUB_RELEASE_BINARY.$GOOS.$GOARCH
         skip_cleanup: true
         on:
             repo: $GITHUB_RELEASE_DEPLOY_REPO


### PR DESCRIPTION
this is a continuation of https://tracker.mender.io/browse/MEN-1836

introducing arch/os releases via a build matrix. this is somewhat a test PR, not sure how this will work before it's merged.

alternatively, we could just copy/paste arch vs os builds in the travis file, but this seems to be a the canonical use case for a matrix, so I suggest going with it. the downside is that we also mix JOB_TYPE into the matrix, so we have to be careful about what and when we're doing (say, only run future acceptance tests if $GOOS=linux).

@maciejmrowiec @kjaskiewiczz 


