### PR TITLE
travis: conditional deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,4 @@ deploy:
             repo: $GITHUB_RELEASE_DEPLOY_REPO
             tags: true
             all_branches: true
+            condition: $JOB_TYPE=deploy


### PR DESCRIPTION
upon tagging, all 3 jobs are ran, but we want to build only if JOB_TYPE = deploy.

add the condition to the 'deploy' step, all providers support it.

net result:
- on a PR, only tests are ran (JOB_TYPE=compile_and_basic_tests);
the 'deploy' job is short-circuited with the $TRAVIS_TAG condition
- on tagging, 'compile_and_basic_tests' is short-circuited; OTOH,
'deploy' jobs run for 2xOS, and 2 binaries are emitted as per the build matrix

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>