### PR TITLE
travis: build platform/os binaries also when no tag specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
       fi
 
     # Only build platform/os releases on deploy, and if we're tagging
-    - if [ "$JOB_TYPE" = deploy ]  && [ -n $TRAVIS_TAG ]; then
+    - if [ "$JOB_TYPE" = deploy ]; then
         CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -o "$BUILD_DIR/$GITHUB_RELEASE_BINARY.$OS.$ARCH" -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`";
       fi
 


### PR DESCRIPTION
we want to push 'latest' to s3 on every merge, so those binaries are needed.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>