### PR TITLE
travis: create build dir unconditionally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ before_script:
     - gocyclo -over 15 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`
 
 script:
+    - mkdir "$BUILD_DIR"
     - if [ "$JOB_TYPE" = compile_and_basic_tests ] && [ -z $TRAVIS_TAG ]; then
         go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $?;
       fi


### PR DESCRIPTION
it seems that even though the s3 provider won't push on unit tests job
(disable via condition), it still needs the dir to exist. test out this possibility.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>