### PR TITLE
misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # mender-cli
-A general-purpose CLI for the Mender backend
+A general-purpose CLI for the Mender server

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -142,13 +142,13 @@ func (c *LoginCmd) saveToken(t []byte) error {
 	dir := filepath.Dir(c.tokenPath)
 	log.Verbf("creating directory: %v\n", dir)
 
-	err := os.MkdirAll(dir, os.ModeDir|os.ModePerm)
+	err := os.MkdirAll(dir, os.ModeDir|0700)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create directory %s", dir)
 
 	}
 
-	err = ioutil.WriteFile(c.tokenPath, t, os.ModePerm)
+	err = ioutil.WriteFile(c.tokenPath, t, 0600)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create file %s", c.tokenPath)
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,8 +31,6 @@ const (
 	argLoginUsername = "username"
 	argLoginPassword = "password"
 	argLoginToken    = "token"
-
-	defaultTokenPath = "/tmp/mendersoftware/authtoken"
 )
 
 var loginCmd = &cobra.Command{
@@ -52,6 +50,7 @@ func init() {
 
 	loginCmd.Flags().StringP(argLoginPassword, "", "", "password (will prompt if not provided)")
 	loginCmd.Flags().StringP(argLoginToken, "", "", "token file path")
+
 }
 
 type LoginCmd struct {
@@ -89,7 +88,10 @@ func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
 	}
 
 	if token == "" {
-		token = defaultTokenPath
+		token, err = getDefaultAuthTokenPath()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &LoginCmd{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -37,7 +37,7 @@ const (
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Log in to the Mender backend (required before other operations).",
+	Short: "Log in to the Mender server (required before other operations).",
 	Run: func(c *cobra.Command, args []string) {
 		cmd, err := NewLoginCmd(c, args)
 		CheckErr(err)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,7 +50,7 @@ func init() {
 	loginCmd.Flags().StringP(argLoginUsername, "", "", "username, format: email (required)")
 	loginCmd.MarkFlagRequired(argLoginUsername)
 
-	loginCmd.Flags().StringP(argLoginPassword, "", "", "password")
+	loginCmd.Flags().StringP(argLoginPassword, "", "", "password (will prompt if not provided)")
 	loginCmd.Flags().StringP(argLoginToken, "", "", "token file path")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ const (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "mender-cli",
-	Short: "A general-purpose CLI for the Mender backend.",
+	Short: "A general-purpose CLI for the Mender server.",
 
 	//setup global stuff, will run regardless of (sub)command
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -54,7 +54,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringP(argRootServer, "", "", "root backend URL, e.g. 'https://hosted.mender.io' (required)")
+	rootCmd.PersistentFlags().StringP(argRootServer, "", "", "root server URL, e.g. 'https://hosted.mender.io' (required)")
 	rootCmd.MarkPersistentFlagRequired(argRootServer)
 	rootCmd.PersistentFlags().BoolP(argRootSkipVerify, "k", false, "skip SSL certificate verification")
 	rootCmd.PersistentFlags().BoolP(argRootVerbose, "v", false, "print verbose output")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -33,7 +33,7 @@ func getDefaultAuthTokenPath() (string, error) {
 		return "", err
 	}
 
-	token := filepath.Join(user.HomeDir, ".mendersoftware", "authtoken")
+	token := filepath.Join(user.HomeDir, ".mender", "authtoken")
 
 	return token, nil
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -16,6 +16,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/user"
+	"path/filepath"
 )
 
 func CheckErr(e error) {
@@ -23,4 +25,15 @@ func CheckErr(e error) {
 		fmt.Fprintf(os.Stderr, "FAILURE: %s\n", e.Error())
 		os.Exit(1)
 	}
+}
+
+func getDefaultAuthTokenPath() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	token := filepath.Join(user.HomeDir, ".mendersoftware", "authtoken")
+
+	return token, nil
 }


### PR DESCRIPTION
@estenberg suggested:
- changing wording `s/backend/server` across the board
- adding password prompt explanation
- storing the token in user's homedir by default

so here goes. there is no task attached, these are ninja fixes.

technical note: you can find discussions about how `os/user` will not work for cross-compiled binaries, and people in fact create libraries that work around this. I didn't want to pull those in so instead we tested that the CLI actually works ok on a macos. so, we stick to the stadard lib after all as the info seems to refer to earlier versions of go.