### PR TITLE
acceptance tests: setup + 'login' test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     # Run test task(s) and platform/arch builds separately
     matrix:
         - JOB_TYPE=compile_and_basic_tests
+        - JOB_TYPE=acceptance_tests
         - JOB_TYPE=deploy ARCH=amd64 OS=linux
         - JOB_TYPE=deploy ARCH=amd64 OS=darwin
 
@@ -59,6 +60,19 @@ script:
     - mkdir "$BUILD_DIR"
     - if [ "$JOB_TYPE" = compile_and_basic_tests ] && [ -z $TRAVIS_TAG ]; then
         go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $?;
+      fi
+
+    - if [ "$JOB_TYPE" = acceptance_tests ]; then
+        git clone -b master https://github.com/mendersoftware/integration.git;
+        mv integration ./tests
+
+        go build ;
+        cp mender-cli ./tests ;
+
+        sudo docker build -f ./tests/Dockerfile -t testing .;
+
+        TESTS_DIR=$PWD/tests ./tests/integration/extra/travis-testing/run-test-environment "acceptance" ./tests/integration ./tests/docker-compose.acceptance.yml ;
+
       fi
 
     # Only build platform/os releases on deploy, and if we're tagging

--- a/client/useradm/client.go
+++ b/client/useradm/client.go
@@ -79,7 +79,7 @@ func (c *Client) Login(user, pass string) ([]byte, error) {
 	}
 
 	if rsp.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf("login failed wih status %d", rsp.StatusCode))
+		return nil, errors.New(fmt.Sprintf("login failed with status %d", rsp.StatusCode))
 	}
 
 	return body, nil

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get -y -qq update && apt-get -qq -y install \
+    python3-pip \
+    python3-pytest
+
+RUN mkdir -p /tests
+ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pip \
-    python3-pytest
+    python3-pytest \
+    docker.io \
+    docker-compose
 
 RUN mkdir -p /tests
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -4,6 +4,9 @@ services:
         image: testing
         networks:
             - mender
+        depends_on:
+            - mender-useradm
+            - mender-api-gateway
         volumes:
             - "${TESTS_DIR}:/tests"
             - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -1,8 +1,9 @@
 version: '2'
 services:
     acceptance:
-        image: tests
+        image: testing
         networks:
             - mender
         volumes:
             - "${TESTS_DIR}:/tests"
+            - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+    acceptance:
+        image: tests
+        networks:
+            - mender
+        volumes:
+            - "${TESTS_DIR}:/tests"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DIR=$(readlink -f $(dirname $0))
+
+[ $$ -eq 1 ] && sleep 10
+
+py.test-3 -s --tb=short \
+          --verbose --junitxml=$DIR/results.xml \
+          $DIR/tests/test_*.py "$@"

--- a/tests/tests/cli.py
+++ b/tests/tests/cli.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+# Copyright 2018 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import subprocess
+
+MENDER_CLI='tests/mender-cli'
+
+class Cli:
+    """Simple wrapper for subprocess"""
+    def __init__(self, path=MENDER_CLI):
+        self.path = path
+
+    def run(self, *argv):
+        """Returns a CompletedProcess wrapped in CliResult"""
+        args = [self.path] + list(argv)
+        completed = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return CliResult(completed)
+
+class CliResult:
+    """Wraps CompletedProcess, decodes output to strings"""
+    def __init__(self, completed_process):
+        self.completed_process = completed_process
+
+        self.returncode = completed_process.returncode
+        self.stdout = self.completed_process.stdout.decode('utf-8')
+        self.stderr = self.completed_process.stderr.decode('utf-8')

--- a/tests/tests/docker.py
+++ b/tests/tests/docker.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# Copyright 2018 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import cli
+
+BASE_COMPOSE_FILES = [
+    "/tests/integration/docker-compose.yml",
+    "/tests/integration/docker-compose.storage.minio.yml",
+    "/tests/integration/docker-compose.testing.yml",
+]
+
+def exec(service, files, *argv):
+    c = cli.Cli('/usr/bin/docker-compose')
+
+    # set by run-test-environment
+    args = ['-p', 'acceptance-tests']
+
+    for f in files:
+        args += ['-f', f]
+
+    args += ['exec', '-T', service] + list(argv)
+
+    return c.run(*args)

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# Copyright 2018 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+MENDER_CLI = '/testing/mender-cli'
+
+class TestLogin:
+    def test_ok(self):
+        pass


### PR DESCRIPTION
this takes care of 2 tasks actually:

https://tracker.mender.io/browse/MEN-1843
https://tracker.mender.io/browse/MEN-1842

this is more of an integration test - real services are used. 

conventions are similar to most acceptance tests, differences:
- docker socket is mounted in the testing container so that commands can be called on peer containers
- the whole 'integration' clone is mounted inside the container too (access to compose files)
- we don't intend to use bravado, just plain requests, so it's not being installed and the setup is simpler
- no 'common' and 'conftest' modules, we'll introduce them as we go (new policy is to keep e.g. fixtures private to tests - they rarely are truly reusable, and cause problems when we do reuse them)
- coverage is not collected yet - not sure we want it and it's problematic (aggregate coverage across executions)

