### PR TITLE
MEN-2895: Clean build recipe and publish Mac OS X binary to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+mender-cli
+mender-cli.linux.amd64
+mender-cli.darwin.amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,26 +98,16 @@ test:acceptance:
   tags:
     - docker
 
-.template_compile: &compile
+compile:
   stage: build
   script:
-    - CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -o "$GITHUB_RELEASE_BINARY.$OS.$ARCH" -ldflags "-X main.Commit=`echo $CI_COMMIT_SHA` -X main.Tag=`echo $CI_COMMIT_TAG` -X main.Branch=`echo $CI_COMMIT_REF_NAME` -X main.BuildNumber=`echo $CI_JOB_ID`"
-    - cp /go/src/$(dirname $REPO_NAME)/mender-cli/$GITHUB_RELEASE_BINARY.$OS.$ARCH $CI_PROJECT_DIR/
+    - make build-multiplatform
+    - cp /go/src/$(dirname $REPO_NAME)/mender-cli/mender-cli.linux.amd64 $CI_PROJECT_DIR/
+    - cp /go/src/$(dirname $REPO_NAME)/mender-cli/mender-cli.darwin.amd64 $CI_PROJECT_DIR/
   artifacts:
     paths:
-      - $GITHUB_RELEASE_BINARY.$OS.$ARCH
-
-compile:linux:
-  <<: *compile
-  variables:
-    OS: linux
-    ARCH: amd64
-
-compile:osx:
-  <<: *compile
-  variables:
-    OS: darwin
-    ARCH: amd64
+      - mender-cli.linux.amd64
+      - mender-cli.darwin.amd64
 
 publish:tests:
   image: alpine
@@ -134,14 +124,19 @@ publish:s3:
   stage: publish
   image: debian:buster
   dependencies:
-    - compile:linux
+    - compile
   before_script:
     - apt update && apt install -yyq awscli
   script:
     - echo "Publishing ${CI_COMMIT_REF_NAME} version for linux to S3"
     - aws s3 cp $GITHUB_RELEASE_BINARY.linux.amd64
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/mender-cli
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/linux/mender-cli
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/mender-cli
+        --key $S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/linux/mender-cli
+    - echo "Publishing ${CI_COMMIT_REF_NAME} version for darwin to S3"
+    - aws s3 cp $GITHUB_RELEASE_BINARY.darwin.amd64
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/darwin/mender-cli
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/darwin/mender-cli
   only:
     - /^(master|[0-9]+\.[0-9]+\.x)$/

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ PKGFILES = $(shell find . \( -path ./vendor -o -path ./Godeps \) -prune \
 PKGFILES_notest = $(shell echo $(PKGFILES) | tr ' ' '\n' | grep -v _test.go)
 GOCYCLO ?= 15
 
-CGO_ENABLED=1
-export CGO_ENABLED
-
 TOOLS = \
 	github.com/fzipp/gocyclo \
 	github.com/opennota/check/cmd/varcheck \
@@ -34,10 +31,16 @@ BUILDTAGS = -tags '$(TAGS)'
 endif
 
 build:
-	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+	CGO_ENABLED=0 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+
+build-multiplatform:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) \
+	     -o mender-cli.linux.amd64
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) \
+	     -o mender-cli.darwin.amd64
 
 install:
-	$(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+	CGO_ENABLED=0 $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
 clean:
 	$(GO) clean

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ To start using `mender-cli`, we recommend that you begin with the
 [documentation section to set up mender-cli](https://docs.mender.io/server-integration/using-the-apis#set-up-mender-cli).
 
 
+## Downloading the binaries
+
+You can find the latest `mender-cli` binaries in the [Downloads page on Mender
+Docs](https://docs.mender.io/downloads).
+
 ## Contributing
 
 We welcome and ask for your contribution. If you would like to contribute to


### PR DESCRIPTION
Clean build recipe and publish Mac OS X binary to S3
    
Add a new target in Makefile that can be used from CI, so that we don't
have two different slightly different ways of building the binary.
    
Also, disable CGO_ENABLED in all targets while unifying and add binaries
to .gitignore.