### PR TITLE
Add Bash and Zsh auto-completion functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mender-cli
 mender-cli.linux.amd64
 mender-cli.darwin.amd64
+autocomplete/

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ endif
 build:
 	CGO_ENABLED=0 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
+build-autocomplete-scripts: build
+	@./mender-cli --generate-autocomplete
+
 build-multiplatform:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) \
 	     -o mender-cli.linux.amd64
@@ -41,6 +44,16 @@ build-multiplatform:
 
 install:
 	CGO_ENABLED=0 $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+
+install-autocomplete-scripts: build-autocomplete-scripts
+	@echo "Installing Bash auto-complete script into ${DESTDIR}${PREFIX}/etc/bash_completion.d/"
+	@install -d ${DESTDIR}$(PREFIX)/etc/bash_completion.d/
+	@install -m 644 ./autocomplete/autocomplete.sh $(DESTDIR)$(PREFIX)/etc/bash_completion.d/
+	@if which zsh >/dev/null 2>&1 ; then \
+	echo "Installing zsh auto-complete script into ${DESTDIR}${PREFIX}/usr/local/share/zsh/site-functions/" \
+	install -d $(DESTDIR)$(PREFIX)/usr/local/share/zsh/site-functions/ && \
+	install -m 644 ./autocomplete/autocomplete.zsh $(DESTDIR)$(PREFIX)/usr/local/share/zsh/site-functions/_mender-cli \
+	; fi
 
 clean:
 	$(GO) clean

--- a/README.md
+++ b/README.md
@@ -30,12 +30,25 @@ To start using `mender-cli`, we recommend that you begin with the
 You can find the latest `mender-cli` binaries in the [Downloads page on Mender
 Docs](https://docs.mender.io/downloads).
 
-## Enabling Bash auto-complete
+## Autocompletion
+
+Autocompletion can be enabled for the `mender-cli` tool through one of two ways.
+
+1. `sudo make install-autocomplete-scripts`
+
+This is the simplest option, and will automatically generate and install the
+auto-completion scripts for both `Bash` and `Zsh`, and install them into the
+appropriate directories. That is `Bash` autocompletion goes into the
+`/etc/bash_completion.d/` directory, and `Zsh` scripts (if `Zsh` is installed),
+gets installed into the `/usr/local/share/zsh/site-functions/` directory.
+
+2. Manually
+
+### Enabling Bash auto-complete manually
 
 The `mender-cli` tool can be enabled to support shell autocompletion, like you
 are used to for your regular tools, like `git`, `cd`, etc. In order to enable
-this functionality the `mender-cli` tool has to be run with the
-`--generate` flag. Example:
+this functionality run the `mender-cli` tool with the `--generate` flag. Example:
 
 ```console
 mender-cli --generate
@@ -56,10 +69,10 @@ completions (i.e., source it). This can be done in one of two ways:
    /path/to/mender-cli/autocomplete/autocomplete.sh" >> ~/.bashrc` needs to be
    present in your `Bash` config.
 
-## Enabling Zsh auto-complete
+### Enabling Zsh auto-complete manually
 
 The `mender-cli` tool supports enabling `Zsh` support, just like [Bash
-auto-completion](#enabling-bash-auto-complete).
+auto-completion](#enabling-bash-auto-complete-manually).
 
 In order to enable `Zsh` auto-completion do:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ To start using `mender-cli`, we recommend that you begin with the
 You can find the latest `mender-cli` binaries in the [Downloads page on Mender
 Docs](https://docs.mender.io/downloads).
 
+## Enabling Bash auto-complete
+
+The `mender-cli` tool can be enabled to support shell autocompletion, like you
+are used to for your regular tools, like `git`, `cd`, etc. In order to enable
+this functionality the `mender-cli` tool has to be run with the
+`--generate` flag. Example:
+
+```console
+mender-cli --generate
+```
+
+This will output the file `autocomplete.sh` in the `autocomplete` directory in
+the directory the binary is run from, so it is recommended to run this from the
+`mender-cli` source directory, where this directory already exists.
+
+In order to enable the functionality the current `Bash` shell has to pick up the
+completions (i.e., source it). This can be done in one of two ways:
+
+1. Copy the `./autocomplete/autocomplete.sh` file to `/etc/bash_completion.d/`,
+   where a new `Bash` shell will automatically source it on invocation.
+
+2. Keep the file where it is, and have each new login shell source the file as a
+   part of `.bashrc`. This means that `echo "source
+   /path/to/mender-cli/autocomplete/autocomplete.sh" >> ~/.bashrc` needs to be
+   present in your `Bash` config.
+
 ## Contributing
 
 We welcome and ask for your contribution. If you would like to contribute to

--- a/README.md
+++ b/README.md
@@ -56,6 +56,39 @@ completions (i.e., source it). This can be done in one of two ways:
    /path/to/mender-cli/autocomplete/autocomplete.sh" >> ~/.bashrc` needs to be
    present in your `Bash` config.
 
+## Enabling Zsh auto-complete
+
+The `mender-cli` tool supports enabling `Zsh` support, just like [Bash
+auto-completion](#enabling-bash-auto-complete).
+
+In order to enable `Zsh` auto-completion do:
+
+```console
+mender-cli --generate
+```
+
+to generate the auto-completion script.
+
+```console
+echo $FPATH
+```
+
+Choose one of the directories in the `$FPATH`, and then copy the
+`./autocomplete/autocomplete.zsh` script into this directory, and rename it to
+`_mender-cli`, and restart your shell. Now typing:
+
+```console
+mender-cli [Tab]
+```
+
+should result in:
+
+```console
+$ mender-cli [Tab]
+artifacts  -- Operations on mender artifacts.
+login      -- Log in to the Mender server (required before other operation
+```
+
 ## Contributing
 
 We welcome and ask for your contribution. If you would like to contribute to

--- a/cmd/artifacts.go
+++ b/cmd/artifacts.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ import (
 )
 
 var artifactsCmd = &cobra.Command{
-	Use:   "artifacts",
-	Short: "Operations on mender artifacts.",
+	Use:       "artifacts",
+	Short:     "Operations on mender artifacts.",
+	ValidArgs: []string{"upload"},
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ func Execute() {
 	b, _ := rootCmd.Flags().GetBool(argRootGenerate)
 	if b {
 		rootCmd.GenBashCompletionFile("./autocomplete/autocomplete.sh")
+		rootCmd.GenZshCompletionFile("./autocomplete/autocomplete.zsh")
 		return
 	}
 	CheckErr(rootCmd.Execute())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mendersoftware/mender-cli/log"
@@ -25,6 +27,7 @@ const (
 	argRootSkipVerify = "skip-verify"
 	argRootToken      = "token"
 	argRootVerbose    = "verbose"
+	argRootGenerate   = "generate-autocomplete"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -42,13 +45,18 @@ var rootCmd = &cobra.Command{
 			log.Verb(fmt.Sprintf("verbose output is ON"))
 		}
 	},
+	ValidArgs: []string{"artifacts", "help", "login"},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.AddCommand(loginCmd)
-	rootCmd.AddCommand(artifactsCmd)
+	rootCmd.LocalFlags().Parse(os.Args)
+	b, _ := rootCmd.Flags().GetBool(argRootGenerate)
+	if b {
+		rootCmd.GenBashCompletionFile("./autocomplete/autocomplete.sh")
+		return
+	}
 	CheckErr(rootCmd.Execute())
 }
 
@@ -61,4 +69,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolP(argRootSkipVerify, "k", false, "skip SSL certificate verification")
 	rootCmd.PersistentFlags().StringP(argRootToken, "", "", "token file path")
 	rootCmd.PersistentFlags().BoolP(argRootVerbose, "v", false, "print verbose output")
+	rootCmd.Flags().Bool(argRootGenerate, false, "generate shell completion script")
+	rootCmd.Flags().MarkHidden(argRootGenerate)
+	rootCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(artifactsCmd)
 }


### PR DESCRIPTION

1. Add `Bash` auto-completion functionality. Just easy to add, and nice to have.

2. Add `Zsh` auto-completion functionality.

3. Add Makefile targets for generating and installing the auto-completion scripts.