### PR TITLE
Add: Make the server flag default to hosted Mender

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,8 +56,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringP(argRootServer, "", "", "root server URL, e.g. 'https://hosted.mender.io' (required)")
-	rootCmd.MarkPersistentFlagRequired(argRootServer)
+	rootCmd.PersistentFlags().StringP(argRootServer, "", "https://hosted.mender.io", "root server URL, e.g. 'https://hosted.mender.io' (default)")
 	rootCmd.PersistentFlags().BoolP(argRootSkipVerify, "k", false, "skip SSL certificate verification")
 	rootCmd.PersistentFlags().StringP(argRootToken, "", "", "token file path")
 	rootCmd.PersistentFlags().BoolP(argRootVerbose, "v", false, "print verbose output")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -96,13 +96,3 @@ class TestArtifactUpload:
 
         assert r.returncode!=0
         expect_output(r.stderr, 'FAILURE', 'Please Login first')
-
-    def test_error_no_server(self, valid_artifact, clean_deployments_db):
-        c = cli.Cli()
-        r = c.run('--skip-verify', \
-                  'artifacts', 'upload', \
-                  '--description', 'foo',
-                  valid_artifact)
-
-        assert r.returncode!=0
-        expect_output(r.stderr, '"server" not set')

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -92,17 +92,5 @@ class TestLogin:
 
         expect_output(r.stderr, 'FAILURE: login failed with status 401')
 
-    def test_error_no_server(self, single_user):
-        c = cli.Cli()
-
-        r = c.run('login', \
-                  '--skip-verify', \
-                  '--username', 'user@tenant.com', \
-                  '--password', 'youcantguess')
-
-        assert r.returncode != 0
-
-        expect_output(r.stderr, '"server" not set')
-
     def __check_token_at(self, path):
         assert os.path.isfile(path)


### PR DESCRIPTION
This makes more sense I think, as we generally want users to default to hosted.
Having to manually enter it every time is also annoying.

Thus only when you want the server to point somewhere else enter the alternative server URI.

A follow up to this would be a configuration file with you username and password I think, so that it could automatically login, and we can skip a whole step when doing stuff with the CLI tool.