### PR TITLE
QA-229: cleanup pipeline and Makefile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,10 @@ test_acc_prep:tools:
   image: golang:1.14
   stage: test_acc_prep
   script:
-    - go build -o $CI_PROJECT_DIR/mender-cli
-    - chmod +x $CI_PROJECT_DIR/mender-cli
-    - wget -q -O $CI_PROJECT_DIR/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/mender-artifact
-    - chmod +x $CI_PROJECT_DIR/mender-artifact
+    - apt-get update && apt-get install make
+    # make target env var
+    - export PROJECT_DIR="$CI_PROJECT_DIR/"
+    - make build-acceptance-tools
   artifacts:
     untracked: true
     paths:
@@ -40,7 +40,9 @@ test_acc_prep:image:
   services:
     - docker:19.03.5-dind
   script:
-    - docker build -t testing -f tests/Dockerfile .
+    - apk add make
+    - export PROJECT_DIR="$CI_PROJECT_DIR/"
+    - make build-acceptance-image
     - docker save testing > $CI_PROJECT_DIR/acceptance_testing_image.tar
   artifacts:
     expire_in: 2w
@@ -76,17 +78,11 @@ test_acc:run:
   services:
     - docker:19.03.5-dind
   script:
-    - apk add git bash
+    - apk add git bash make
     - docker load -i acceptance_testing_image.tar
     - export SHARED_PATH="$(dirname ${CI_PROJECT_DIR})/shared"
-    - mkdir -p ${SHARED_PATH} && mv mender-artifact mender-cli tests/* ${SHARED_PATH}
-    - git clone -b master https://github.com/mendersoftware/integration.git ${SHARED_PATH}/integration
-    # this is basically https://github.com/mendersoftware/integration/blob/master/tests/run.sh#L51
-    # to allow the tests to be run, as the composition is now generated during test image build
-    - sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/ports:/d' ${SHARED_PATH}/integration/docker-compose.demo.yml > ${SHARED_PATH}/integration/docker-compose.testing.yml
-    - sed -e 's/DOWNLOAD_SPEED/#DOWNLOAD_SPEED/' -i ${SHARED_PATH}/integration/docker-compose.testing.yml
-    - sed -e 's/ALLOWED_HOSTS:\ .*/ALLOWED_HOSTS:\ _/' -i ${SHARED_PATH}/integration/docker-compose.testing.yml
-    - TESTS_DIR=${SHARED_PATH} ${SHARED_PATH}/integration/extra/travis-testing/run-test-environment acceptance ${SHARED_PATH}/integration ${SHARED_PATH}/docker-compose.acceptance.yml ;
+    - make run-acceptance
+
   tags:
     - docker
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,9 +20,9 @@ before_script:
   - apt-get update && apt-get install -yyq liblzma-dev
 
 stages:
+  - test
   - test_prep
   - test_fast
-  - test
   - build
   - publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,14 +15,14 @@ variables:
 
 stages:
   - test
-  - test_acc_prep
-  - test_acc
+  - test_acceptance_build
+  - test_acceptance
   - build
   - publish
 
-test_acc_prep:tools:
+test_acceptance_build:tools:
   image: golang:1.14
-  stage: test_acc_prep
+  stage: test_acceptance_build
   script:
     - apt-get update && apt-get install make
     # make target env var
@@ -34,8 +34,8 @@ test_acc_prep:tools:
       - mender-cli
       - mender-artifact
 
-test_acc_prep:image:
-  stage: test_acc_prep
+test_acceptance_build:image:
+  stage: test_acceptance_build
   image: docker
   services:
     - docker:19.03.5-dind
@@ -69,20 +69,20 @@ test:static:
     # Get last remaining tags, if any.
     - git fetch --tags origin
 
-test_acc:run:
-  stage: test_acc
+test_acceptance:run:
+  stage: test_acceptance
   image: tiangolo/docker-with-compose
   dependencies:
-    - test_acc_prep:tools
-    - test_acc_prep:image
+    - test_acceptance_build:tools
+    - test_acceptance_build:image
   services:
     - docker:19.03.5-dind
   script:
     - apk add git bash make
     - docker load -i acceptance_testing_image.tar
+    # make target env var
     - export SHARED_PATH="$(dirname ${CI_PROJECT_DIR})/shared"
     - make run-acceptance
-
   tags:
     - docker
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,14 +21,14 @@ before_script:
 
 stages:
   - test
-  - test_prep
-  - test_fast
+  - test_acc_prep
+  - test_acc
   - build
   - publish
 
-test:build_acceptance:tools:
+test_acc_prep:tools:
   image: golang:1.14
-  stage: test_prep
+  stage: test_acc_prep
   script:
     - go build -o $CI_PROJECT_DIR/mender-cli
     - chmod +x $CI_PROJECT_DIR/mender-cli
@@ -40,8 +40,8 @@ test:build_acceptance:tools:
       - mender-cli
       - mender-artifact
 
-test:build_acceptance:image:
-  stage: test_prep
+test_acc_prep:image:
+  stage: test_acc_prep
   image: docker
   services:
     - docker:19.03.5-dind
@@ -86,12 +86,12 @@ test:checks:
     - make get-go-tools
     - make check
 
-test:acceptance:
-  stage: test_fast
+test_acc:run:
+  stage: test_acc
   image: tiangolo/docker-with-compose
   dependencies:
-    - test:build_acceptance:tools
-    - test:build_acceptance:image
+    - test_acc_prep:tools
+    - test_acc_prep:image
   services:
     - docker:19.03.5-dind
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,19 +73,6 @@ test:static:
     # Get last remaining tags, if any.
     - git fetch --tags origin
 
-
-
-test:checks:
-  <<: *sync_remote_branches
-  stage: test
-  script:
-    - apt-get -qq update && apt-get -qqy install --allow-unauthenticated e2tools
-    # Install code coverage tooling
-    - GO111MODULE=off go get -u github.com/axw/gocov/gocov
-    - GO111MODULE=off go get -u golang.org/x/tools/cmd/cover
-    - make get-go-tools
-    - make check
-
 test_acc:run:
   stage: test_acc
   image: tiangolo/docker-with-compose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,12 +13,6 @@ variables:
   S3_BUCKET_PATH: "mender-cli"
   BUILD_DIR: build
 
-before_script:
-  - mkdir -p /go/src/$(dirname $REPO_NAME)/mender-cli /go/src/_/builds
-  - cp -r $CI_PROJECT_DIR /go/src/$(dirname $REPO_NAME)
-  - cd /go/src/$(dirname $REPO_NAME)/mender-cli
-  - apt-get update && apt-get install -yyq liblzma-dev
-
 stages:
   - test
   - test_acc_prep
@@ -99,6 +93,11 @@ test_acc:run:
 compile:
   image: golang:1.14
   stage: build
+  before_script:
+    - mkdir -p /go/src/$(dirname $REPO_NAME)/mender-cli /go/src/_/builds
+    - cp -r $CI_PROJECT_DIR /go/src/$(dirname $REPO_NAME)
+    - cd /go/src/$(dirname $REPO_NAME)/mender-cli
+    - make get-build-deps
   script:
     - make build-multiplatform
     - cp /go/src/$(dirname $REPO_NAME)/mender-cli/mender-cli.linux.amd64 $CI_PROJECT_DIR/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,14 +53,12 @@ test:build_acceptance:image:
     paths:
       - acceptance_testing_image.tar
 
-test:format:
+test:static:
   image: golang:1.14
   stage: test
-  allow_failure: true
   script:
-    - go fmt $(go list ./... | grep -v /vendor/)
-    - go vet $(go list ./... | grep -v /vendor/)
-    - go test -race $(go list ./... | grep -v /vendor/)
+    - make get-go-tools
+    - make test-static
 
 
 .sync_branches_template: &sync_remote_branches
@@ -85,7 +83,7 @@ test:checks:
     # Install code coverage tooling
     - GO111MODULE=off go get -u github.com/axw/gocov/gocov
     - GO111MODULE=off go get -u golang.org/x/tools/cmd/cover
-    - make get-tools
+    - make get-go-tools
     - make check
 
 test:acceptance:


### PR DESCRIPTION
https://tracker.mender.io/browse/QA-229

- the original problem is of course gone, 
- I took quite a few liberties refactoring it (keeping the makefile targets as similar as possible)

the most important problem was that - both the makefile and gitlab.yml mixed together static testing checks and unit testing, and custom templates with mendertesting templates. generally they were completely out of sync.

Makefile targets are now untangled into smaller ones and used in the ci pipeline wherever possible. you have targets for getting tools (test tools, compile deps), static checks, unit tests, acceptance tests build, run...

there is surely some minimal duplication here and there (or crappy scripting), but that's the best I have...  

TODO: verify the artifact publish stage still works - but that's only after merge.