### PR TITLE
MEN-4318: Add --record and --playback to terminal command

### DIFF
--- a/cmd/terminal.go
+++ b/cmd/terminal.go
@@ -17,6 +17,8 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
+	"encoding/gob"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -40,6 +42,7 @@ import (
 
 	"github.com/mendersoftware/go-lib-micro/ws"
 	wsshell "github.com/mendersoftware/go-lib-micro/ws/shell"
+	"github.com/mendersoftware/mender-cli/log"
 )
 
 const (
@@ -56,12 +59,19 @@ const (
 	// default terminal size
 	defaultTermWidth  = 80
 	defaultTermHeight = 40
+
+	// dummy delay for playback
+	playbackSleep = time.Millisecond * 32
+
+	// cli args
+	argRecord   = "record"
+	argPlayback = "playback"
 )
 
 var terminalCmd = &cobra.Command{
 	Use:   "terminal DEVICE_ID",
 	Short: "Access a device's remote terminal",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	Run: func(c *cobra.Command, args []string) {
 		cmd, err := NewTerminalCmd(c, args)
 		CheckErr(err)
@@ -69,17 +79,57 @@ var terminalCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	terminalCmd.Flags().StringP(argRecord, "", "", "recording file path to save the session to")
+	terminalCmd.Flags().StringP(argPlayback, "", "", "recording file path to playback the session from")
+}
+
 // TerminalCmd handles the terminal command
 type TerminalCmd struct {
-	server      string
-	skipVerify  bool
-	deviceID    string
-	sessionID   string
-	running     bool
-	healthcheck chan int
-	stop        chan struct{}
-	err         error
+	server             string
+	skipVerify         bool
+	deviceID           string
+	sessionID          string
+	running            bool
+	healthcheck        chan int
+	stop               chan struct{}
+	err                error
+	recordFile         string
+	recording          bool
+	stopRecording      chan bool
+	playbackFile       string
+	terminalOutputChan chan []byte
 }
+
+const (
+	deviceIDMaxLength     = 64
+	terminalTypeMaxLength = 32
+	terminalTypeDefault   = "xterm-256color"
+)
+
+type TerminalRecordingHeader struct {
+	Version        uint8
+	DeviceID       [deviceIDMaxLength]byte
+	TerminalType   [terminalTypeMaxLength]byte
+	TerminalWidth  int16
+	TerminalHeight int16
+	Timestamp      int64
+}
+
+const (
+	terminalRecordingVersion = 1
+)
+
+type TerminalRecordingType int8
+
+type TerminalRecordingData struct {
+	Type TerminalRecordingType
+	Data []byte
+}
+
+const (
+	terminalRecordingOutput TerminalRecordingType = iota
+)
 
 // NewTerminalCmd returns a new TerminalCmd
 func NewTerminalCmd(cmd *cobra.Command, args []string) (*TerminalCmd, error) {
@@ -93,12 +143,31 @@ func NewTerminalCmd(cmd *cobra.Command, args []string) (*TerminalCmd, error) {
 		return nil, err
 	}
 
+	recordFile, err := cmd.Flags().GetString(argRecord)
+	if err != nil {
+		return nil, err
+	}
+
+	playbackFile, err := cmd.Flags().GetString(argPlayback)
+	if err != nil {
+		return nil, err
+	}
+
+	deviceID := ""
+	if len(args) == 1 {
+		deviceID = args[0]
+	}
+
 	return &TerminalCmd{
-		server:      server,
-		skipVerify:  skipVerify,
-		deviceID:    args[0],
-		healthcheck: make(chan int),
-		stop:        make(chan struct{}),
+		server:             server,
+		skipVerify:         skipVerify,
+		deviceID:           deviceID,
+		healthcheck:        make(chan int),
+		stop:               make(chan struct{}),
+		recordFile:         recordFile,
+		stopRecording:      make(chan bool),
+		terminalOutputChan: make(chan []byte),
+		playbackFile:       playbackFile,
 	}, nil
 }
 
@@ -236,6 +305,91 @@ func (c *TerminalCmd) stopShell(conn *websocket.Conn) error {
 	return nil
 }
 
+func (c *TerminalCmd) record() {
+	f, err := os.Create(c.recordFile)
+	if err != nil {
+		log.Err(fmt.Sprintf("Can't create recording file: %s: %s", c.recordFile, err.Error()))
+	}
+	defer f.Close()
+
+	data := TerminalRecordingHeader{
+		Version:        terminalRecordingVersion,
+		Timestamp:      time.Now().Unix(),
+		TerminalWidth:  defaultTermWidth,
+		TerminalHeight: defaultTermHeight,
+	}
+	copy(data.DeviceID[:], []byte(c.deviceID))
+	copy(data.TerminalType[:], []byte(terminalTypeDefault))
+	err = binary.Write(f, binary.LittleEndian, data)
+	if err != nil {
+		log.Err(fmt.Sprintf("Header write failed: %s", err.Error()))
+	}
+
+	log.Info(fmt.Sprintf("Recording to file: %s", c.recordFile))
+
+	e := gob.NewEncoder(f)
+	for {
+		select {
+		case <-c.stopRecording:
+			return
+		case terminalOutput := <-c.terminalOutputChan:
+			o := TerminalRecordingData{
+				Type: terminalRecordingOutput,
+				Data: terminalOutput,
+			}
+			err = e.Encode(o)
+			if err != nil {
+				log.Err(fmt.Sprintf("Error encoding %q: %s", string(terminalOutput), err.Error()))
+				return
+			}
+		}
+	}
+}
+
+func (c *TerminalCmd) playback(w io.Writer) error {
+	f, err := os.Open(c.playbackFile)
+	if err != nil {
+		log.Err(fmt.Sprintf("Can't open %s: %s", c.playbackFile, err.Error()))
+		return err
+	}
+	defer f.Close()
+
+	var header TerminalRecordingHeader
+	err = binary.Read(f, binary.LittleEndian, &header)
+	if err != nil {
+		log.Err(fmt.Sprintf("Can't read header: %s", err.Error()))
+		return err
+	}
+
+	dateTime := time.Unix(header.Timestamp, 0)
+
+	log.Info(fmt.Sprintf("Playing back from file: %s", c.playbackFile))
+	log.Info(fmt.Sprintf("Device ID: %s", string(header.DeviceID[:])))
+	log.Info(fmt.Sprintf("Terminal type: %s", string(header.TerminalType[:])))
+	log.Info(fmt.Sprintf("Terminal size: %dx%d", header.TerminalWidth, header.TerminalHeight))
+	log.Info(fmt.Sprintf("Timestamp: %s", dateTime.Format(time.UnixDate)))
+	log.Info("")
+
+	d := gob.NewDecoder(f)
+	for {
+		var o TerminalRecordingData
+		err = d.Decode(&o)
+		if err != nil {
+			if err != io.EOF {
+				log.Err(fmt.Sprintf("Decoding error: %s", err.Error()))
+				return err
+			}
+			break
+		}
+		if o.Type == terminalRecordingOutput {
+			w.Write(o.Data)
+		}
+		time.Sleep(playbackSleep)
+	}
+	log.Info("\r")
+	return nil
+}
+
 // Run executes the command
 func (c *TerminalCmd) Run() error {
 	ctx, cancelContext := context.WithCancel(context.Background())
@@ -255,6 +409,21 @@ func (c *TerminalCmd) Run() error {
 			return errors.Wrap(err, "Unable to get the terminal size")
 		}
 		isTerminal = true
+	}
+
+	// when playing back, no further processing is required
+	if _, err := os.Stat(c.playbackFile); err == nil {
+		return c.playback(os.Stdout)
+	}
+
+	// start recording when applicable
+	if _, err := os.Stat(c.recordFile); os.IsNotExist(err) {
+		if len(c.recordFile) > 0 {
+			c.recording = true
+			go c.record()
+		}
+	} else {
+		log.Err(fmt.Sprintf("Can't create recording file: %s exists, refused to record.", c.recordFile))
 	}
 
 	// connect to the websocket
@@ -369,6 +538,9 @@ func (c *TerminalCmd) resizeTerminal(ctx context.Context, msgChan chan *ws.Proto
 func (c *TerminalCmd) Stop() {
 	c.running = false
 	c.stop <- struct{}{}
+	if c.recording {
+		c.stopRecording <- true
+	}
 }
 
 func (c *TerminalCmd) pipeStdin(msgChan chan *ws.ProtoMsg, r io.Reader) {
@@ -425,6 +597,9 @@ func (c *TerminalCmd) pipeStdout(msgChan chan *ws.ProtoMsg, conn *websocket.Conn
 		if m.Header.Proto == ws.ProtoTypeShell && m.Header.MsgType == wsshell.MessageTypeShellCommand {
 			if _, err := w.Write(m.Body); err != nil {
 				break
+			}
+			if c.recording {
+				c.terminalOutputChan <- m.Body
 			}
 		} else if m.Header.Proto == ws.ProtoTypeShell && m.Header.MsgType == wsshell.MessageTypePingShell {
 			if healthcheckTimeout, ok := m.Header.Properties["timeout"].(int64); ok && healthcheckTimeout > 0 {


### PR DESCRIPTION
* MEN-4318: Add --record and --playback to terminal command
Save first a header with some meta-data, and then encode the stream of
bytes from stdout. Only stdout is recorded.
Made the positional argument for `terminal` command optional, as now for
playback we don't need to connect to any device.
Changelog: `mender-cli --record <my-file> terminal <DEVICE-ID>` records
the terminal session into a local file.
Changelog: `mender-cli --playback <my-file> terminal` playbacks the
previously recorded terminal session from a local file.

* MEN-4318: Compress terminal recording file
