### PR TITLE
Fix: Respect the --server flag from config everywhere

### DIFF
--- a/cmd/artifact_upload.go
+++ b/cmd/artifact_upload.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/mendersoftware/mender-cli/client/deployments"
 	"github.com/mendersoftware/mender-cli/log"
@@ -52,9 +55,9 @@ type ArtifactUploadCmd struct {
 }
 
 func NewArtifactUploadCmd(cmd *cobra.Command, args []string) (*ArtifactUploadCmd, error) {
-	server, err := cmd.Flags().GetString(argRootServer)
-	if err != nil {
-		return nil, err
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("No server")
 	}
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)

--- a/cmd/artifacts_list.go
+++ b/cmd/artifacts_list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/mendersoftware/mender-cli/client/deployments"
 )
@@ -46,9 +49,9 @@ type ArtifactsListCmd struct {
 }
 
 func NewArtifactsListCmd(cmd *cobra.Command, args []string) (*ArtifactsListCmd, error) {
-	server, err := cmd.Flags().GetString(argRootServer)
-	if err != nil {
-		return nil, err
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("No server")
 	}
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,22 +51,8 @@ func init() {
 	loginCmd.Flags().StringP(argLoginUsername, "", "", "username, format: email (will prompt if not provided)")
 	loginCmd.Flags().StringP(argLoginPassword, "", "", "password (will prompt if not provided)")
 	loginCmd.Flags().StringP(argLoginToken, "", "", "two-factor authentication token")
-
-	viper.SetConfigName(".mender-clirc")
-	viper.SetConfigType("json")
-	viper.AddConfigPath("/etc/mender-cli/")
-	viper.AddConfigPath("$HOME/")
-	viper.AddConfigPath(".")
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			log.Info(fmt.Sprintf("Failed to read config: %s", err))
-			os.Exit(1)
-		} else {
-			log.Info("Configuration file not found. Continuing.")
-		}
-	} else {
-		fmt.Fprintf(os.Stderr, "Using configuration file: %s\n", viper.ConfigFileUsed())
-	}
+	viper.BindPFlag(argLoginUsername, loginCmd.Flags().Lookup(argLoginUsername))
+	viper.BindPFlag(argLoginPassword, loginCmd.Flags().Lookup(argLoginPassword))
 }
 
 type LoginCmd struct {
@@ -79,9 +65,6 @@ type LoginCmd struct {
 }
 
 func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
-	viper.BindPFlag(argRootServer, cmd.Flags().Lookup(argRootServer))
-	viper.BindPFlag(argLoginUsername, cmd.Flags().Lookup(argLoginUsername))
-	viper.BindPFlag(argLoginPassword, cmd.Flags().Lookup(argLoginPassword))
 	server := viper.GetString(argRootServer)
 	if server == "" {
 		return nil, errors.New("No server, this should not happen")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/mendersoftware/mender-cli/log"
 )
@@ -32,6 +33,24 @@ const (
 	argRootGenerate   = "generate-autocomplete"
 	argRootVersion    = "version"
 )
+
+func init() {
+	viper.SetConfigName(".mender-clirc")
+	viper.SetConfigType("json")
+	viper.AddConfigPath("/etc/mender-cli/")
+	viper.AddConfigPath("$HOME/")
+	viper.AddConfigPath(".")
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			log.Info(fmt.Sprintf("Failed to read config: %s", err))
+			os.Exit(1)
+		} else {
+			log.Info("Configuration file not found. Continuing.")
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Using configuration file: %s\n", viper.ConfigFileUsed())
+	}
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -74,6 +93,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringP(argRootServer, "", "https://hosted.mender.io", "root server URL, e.g. 'https://hosted.mender.io'")
+	viper.BindPFlag(argRootServer, rootCmd.PersistentFlags().Lookup(argRootServer))
 	rootCmd.PersistentFlags().BoolP(argRootSkipVerify, "k", false, "skip SSL certificate verification")
 	rootCmd.PersistentFlags().StringP(argRootToken, "", "", "token file path")
 	rootCmd.PersistentFlags().BoolP(argRootVerbose, "v", false, "print verbose output")

--- a/cmd/terminal.go
+++ b/cmd/terminal.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vmihailenco/msgpack"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
@@ -82,9 +83,9 @@ type TerminalCmd struct {
 
 // NewTerminalCmd returns a new TerminalCmd
 func NewTerminalCmd(cmd *cobra.Command, args []string) (*TerminalCmd, error) {
-	server, err := cmd.Flags().GetString(argRootServer)
-	if err != nil {
-		return nil, err
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("No server")
 	}
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)


### PR DESCRIPTION
Previously, the configuration --server flag was only bound to the configuration
file value in the login command.

By moving the viper configuration to the root command, and fetching the value
from viper everywhere, the flag is now properly handled everywhere.

Changelog: Title
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>