### PR TITLE
New command devices list

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/mendersoftware/mender-cli/log"
+	"github.com/pkg/errors"
+)
+
+func NewHttpClient(skipVerify bool) *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	return &http.Client{
+		Transport: tr,
+	}
+}
+
+func JoinURL(base, url string) string {
+	if strings.HasPrefix(url, "/") {
+		url = url[1:]
+	}
+	if !strings.HasSuffix(base, "/") {
+		base = base + "/"
+	}
+	return base + url
+}
+
+func DoGetRequest(tokenPath, urlPath string, client *http.Client) ([]byte, error) {
+	token, err := ioutil.ReadFile(tokenPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Please Login first")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create HTTP request")
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+
+	reqDump, err := httputil.DumpRequest(req, false)
+	if err != nil {
+		return nil, err
+	}
+	log.Verbf("sending request: \n%s", string(reqDump))
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("Get %s request failed", urlPath))
+	}
+	if rsp.StatusCode != 200 {
+		return nil, fmt.Errorf("Get %s request failed with status %d\n", urlPath, rsp.StatusCode)
+	}
+
+	defer rsp.Body.Close()
+
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}

--- a/client/devices/client.go
+++ b/client/devices/client.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package devices
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/mender-cli/log"
+)
+
+type devicesList struct {
+	devices []deviceData
+}
+
+type deviceData struct {
+	ID           string `json:"id"`
+	IdentityData struct {
+		Mac string `json:"mac"`
+		Sku string `json:"sku"`
+		Sn  string `json:"sn"`
+	} `json:"identity_data"`
+	Status    string `json:"status"`
+	CreatedTs string `json:"created_ts"`
+	UpdatedTs string `json:"updated_ts"`
+	AuthSets  []struct {
+		ID           string `json:"id"`
+		PubKey       string `json:"pubkey"`
+		IdentityData struct {
+			Mac string `json:"mac"`
+			Sku string `json:"sku"`
+			Sn  string `json:"sn"`
+		} `json:"identity_data"`
+		Status string `json:"status"`
+		Ts     string `json:"ts"`
+	} `json:"auth_sets"`
+	Decommissioning bool `json:"decommissioning"`
+}
+
+const (
+	devicesListURL = "/api/management/v2/devauth/devices"
+)
+
+type Client struct {
+	url            string
+	devicesListURL string
+	client         *http.Client
+}
+
+func NewClient(url string, skipVerify bool) *Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	return &Client{
+		url:            url,
+		devicesListURL: JoinURL(url, devicesListURL),
+		client: &http.Client{
+			Transport: tr,
+		},
+	}
+}
+
+func (c *Client) ListDevices(tokenPath string, detailLevel int) error {
+	if detailLevel > 3 || detailLevel < 0 {
+		return fmt.Errorf("FAILURE: invalid devices detail")
+	}
+	token, err := ioutil.ReadFile(tokenPath)
+	if err != nil {
+		return errors.Wrap(err, "Please Login first")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.devicesListURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create HTTP request")
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+
+	reqDump, err := httputil.DumpRequest(req, false)
+	if err != nil {
+		return err
+	}
+	log.Verbf("sending request: \n%s", string(reqDump))
+
+	rsp, err := c.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Get /devauth/devices request failed")
+	}
+	if rsp.StatusCode != 200 {
+		return fmt.Errorf("Get /devauth/devices request failed with status %d\n", rsp.StatusCode)
+	}
+
+	defer rsp.Body.Close()
+
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return err
+	}
+
+	var list devicesList
+	err = json.Unmarshal(body, &list.devices)
+	if err != nil {
+		return err
+	}
+	for _, v := range list.devices {
+		listDevice(v, detailLevel)
+	}
+
+	return nil
+}
+
+func listDevice(a deviceData, detailLevel int) {
+	fmt.Printf("ID: %s\n", a.ID)
+	fmt.Printf("Status: %s\n", a.Status)
+	if detailLevel >= 1 {
+		fmt.Println("IdentityData:")
+		if a.IdentityData.Mac != "" {
+			fmt.Printf("  MAC address: %s\n", a.IdentityData.Mac)
+		}
+		if a.IdentityData.Sku != "" {
+			fmt.Printf("  Stock keeping unit: %s\n", a.IdentityData.Sku)
+		}
+		if a.IdentityData.Sn != "" {
+			fmt.Printf("  Serial number: %s\n", a.IdentityData.Sn)
+		}
+	}
+	if detailLevel >= 1 {
+		fmt.Printf("CreatedTs: %s\n", a.CreatedTs)
+		fmt.Printf("UpdatedTs: %s\n", a.UpdatedTs)
+		fmt.Printf("Decommissioning: %t\n", a.Decommissioning)
+	}
+	if detailLevel >= 2 {
+		for i, v := range a.AuthSets {
+			fmt.Printf("AuthSet[%d]:\n", i)
+			fmt.Printf("  ID: %s\n", v.ID)
+			fmt.Printf("  PubKey:\n%s", v.PubKey)
+			fmt.Println("  IdentityData:")
+			if v.IdentityData.Mac != "" {
+				fmt.Printf("    MAC address: %s\n", v.IdentityData.Mac)
+			}
+			if v.IdentityData.Sku != "" {
+				fmt.Printf("    Stock keeping unit: %s\n", v.IdentityData.Sku)
+			}
+			if v.IdentityData.Sn != "" {
+				fmt.Printf("    Serial number: %s\n", v.IdentityData.Sn)
+			}
+			fmt.Printf("  Status: %s\n", v.Status)
+			fmt.Printf("  Ts: %s\n", v.Ts)
+		}
+	}
+
+	fmt.Println("--------------------------------------------------------------------------------")
+}
+
+func JoinURL(base, url string) string {
+	if strings.HasPrefix(url, "/") {
+		url = url[1:]
+	}
+	if !strings.HasSuffix(base, "/") {
+		base = base + "/"
+	}
+	return base + url
+}

--- a/client/useradm/client.go
+++ b/client/useradm/client.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@ package useradm
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/mendersoftware/mender-cli/client"
 	"github.com/mendersoftware/mender-cli/log"
 )
 
@@ -41,16 +40,10 @@ type Client struct {
 }
 
 func NewClient(url string, skipVerify bool) *Client {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
-	}
-
 	return &Client{
 		url:      url,
-		loginUrl: JoinURL(url, loginUrl),
-		client: &http.Client{
-			Transport: tr,
-		},
+		loginUrl: client.JoinURL(url, loginUrl),
+		client:   client.NewHttpClient(skipVerify),
 	}
 }
 
@@ -96,14 +89,4 @@ func (c *Client) Login(user, pass string, token string) ([]byte, error) {
 	}
 
 	return body, nil
-}
-
-func JoinURL(base, url string) string {
-	if strings.HasPrefix(url, "/") {
-		url = url[1:]
-	}
-	if !strings.HasSuffix(base, "/") {
-		base = base + "/"
-	}
-	return base + url
 }

--- a/cmd/artifact_upload.go
+++ b/cmd/artifact_upload.go
@@ -35,7 +35,6 @@ var artifactUploadCmd = &cobra.Command{
 	Run: func(c *cobra.Command, args []string) {
 		cmd, err := NewArtifactUploadCmd(c, args)
 		CheckErr(err)
-
 		CheckErr(cmd.Run())
 	},
 }

--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var devicesCmd = &cobra.Command{
+	Use:       "devices",
+	Short:     "Operations on mender devices.",
+	ValidArgs: []string{"list"},
+}
+
+func init() {
+	devicesCmd.AddCommand(devicesListCmd)
+}

--- a/cmd/devices_list.go
+++ b/cmd/devices_list.go
@@ -19,35 +19,31 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/mendersoftware/mender-cli/client/deployments"
+	"github.com/mendersoftware/mender-cli/client/devices"
 )
 
-const (
-	argDetailLevel = "detail"
-)
-
-var artifactsListCmd = &cobra.Command{
+var devicesListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Get a list of artifacts from the Mender server.",
+	Short: "Get a list of devices from the Mender server.",
 	Run: func(c *cobra.Command, args []string) {
-		cmd, err := NewArtifactsListCmd(c, args)
+		cmd, err := NewDevicesListCmd(c, args)
 		CheckErr(err)
 		CheckErr(cmd.Run())
 	},
 }
 
 func init() {
-	artifactsListCmd.Flags().IntP(argDetailLevel, "d", 0, "artifacts list detail level [0..3]")
+	devicesListCmd.Flags().IntP(argDetailLevel, "d", 0, "devices list detail level [0..3]")
 }
 
-type ArtifactsListCmd struct {
+type DevicesListCmd struct {
 	server      string
 	skipVerify  bool
 	tokenPath   string
 	detailLevel int
 }
 
-func NewArtifactsListCmd(cmd *cobra.Command, args []string) (*ArtifactsListCmd, error) {
+func NewDevicesListCmd(cmd *cobra.Command, args []string) (*DevicesListCmd, error) {
 	server := viper.GetString(argRootServer)
 	if server == "" {
 		return nil, errors.New("No server")
@@ -75,7 +71,7 @@ func NewArtifactsListCmd(cmd *cobra.Command, args []string) (*ArtifactsListCmd, 
 		}
 	}
 
-	return &ArtifactsListCmd{
+	return &DevicesListCmd{
 		server:      server,
 		tokenPath:   token,
 		skipVerify:  skipVerify,
@@ -83,8 +79,8 @@ func NewArtifactsListCmd(cmd *cobra.Command, args []string) (*ArtifactsListCmd, 
 	}, nil
 }
 
-func (c *ArtifactsListCmd) Run() error {
+func (c *DevicesListCmd) Run() error {
 
-	client := deployments.NewClient(c.server, c.skipVerify)
-	return client.ListArtifacts(c.tokenPath, c.detailLevel)
+	client := devices.NewClient(c.server, c.skipVerify)
+	return client.ListDevices(c.tokenPath, c.detailLevel)
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -42,7 +42,6 @@ var loginCmd = &cobra.Command{
 	Run: func(c *cobra.Command, args []string) {
 		cmd, err := NewLoginCmd(c, args)
 		CheckErr(err)
-
 		CheckErr(cmd.Run())
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,5 +102,6 @@ func init() {
 	rootCmd.Flags().MarkHidden(argRootGenerate)
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(artifactsCmd)
+	rootCmd.AddCommand(devicesCmd)
 	rootCmd.AddCommand(terminalCmd)
 }

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -6,6 +6,10 @@ services:
             - mender
         depends_on:
             - mender-useradm
+            - mender-inventory
+            - mender-workflows-server
+            - mender-workflows-worker
+            - mender-device-auth
             - mender-api-gateway
             - mender-deployments
         volumes:

--- a/tests/tests/api.py
+++ b/tests/tests/api.py
@@ -13,8 +13,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import os
+import json
 
 import requests
+
+import crypto
+
+
+def make_api_url(url, path):
+    return os.path.join(url, path if not path.startswith("/") else path[1:])
 
 
 class Deployments:
@@ -24,8 +31,52 @@ class Deployments:
 
     def get_artifacts(self):
         auth = {'Authorization': 'Bearer {}'.format(self.token)}
-        return requests.get(self.make_api_url('/artifacts'), verify=False, headers=auth)
+        return requests.get(make_api_url(self.url, "/artifacts"), verify=False, headers=auth)
 
-    def make_api_url(self, path):
-        return os.path.join(self.url,
-                            path if not path.startswith("/") else path[1:])
+
+class DevicesDevauth:
+    def __init__(self, url="https://mender-api-gateway/api/devices/v1/authentication"):
+        self.url = url
+
+    def auth_req(self, id_data, pubkey, privkey):
+        payload = {
+            "id_data": json.dumps(id_data),
+            "pubkey": pubkey,
+        }
+        signature = crypto.auth_req_sign_rsa(json.dumps(payload), privkey)
+        return payload, {"X-MEN-Signature": signature}
+
+    def post_auth_request(self, authset, pubkey, privkey):
+        body, sighdr = self.auth_req(authset, pubkey, privkey)
+        return requests.post(
+            make_api_url(self.url, "/auth_requests"),
+            verify=False,
+            headers=sighdr,
+            json=body,
+        )
+
+
+class ManagementDevauth:
+    def __init__(
+        self, token, url="https://mender-api-gateway/api/management/v2/devauth"
+    ):
+        self.url = url
+        self.token = token
+
+    def get_devices(self):
+        auth = {"Authorization": "Bearer {}".format(self.token)}
+        return requests.get(
+            make_api_url(self.url, "/devices"), verify=False, headers=auth
+        )
+
+    def set_device_auth_status(self, device_id, authset_id, auth_status):
+        body = {
+            "status": auth_status,
+        }
+        auth = {"Authorization": "Bearer {}".format(self.token)}
+        return requests.put(
+            make_api_url(self.url, f"/devices/{device_id}/auth/{authset_id}/status"),
+            verify=False,
+            headers=auth,
+            json=body,
+        )

--- a/tests/tests/crypto.py
+++ b/tests/tests/crypto.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import random
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from base64 import b64encode
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+def keypair_pem(private_key, public_key):
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem.decode(), public_pem.decode()
+
+
+def rand_id_data():
+    mac = ":".join(["{:02x}".format(random.randint(0x00, 0xFF), "x") for i in range(6)])
+    sn = "".join(["{}".format(random.randint(0x00, 0xFF)) for i in range(6)])
+
+    return {"mac": mac, "sn": sn}
+
+
+def get_keypair_rsa(public_exponent=65537, key_size=1024):
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent, key_size=key_size, backend=default_backend(),
+    )
+
+    return keypair_pem(private_key, private_key.public_key())
+
+
+def auth_req_sign_rsa(data, private_key):
+    key = serialization.load_pem_private_key(
+        private_key if isinstance(private_key, bytes) else private_key.encode(),
+        password=None,
+        backend=default_backend(),
+    )
+
+    signature = key.sign(
+        data if isinstance(data, bytes) else data.encode(),
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+    return b64encode(signature).decode()

--- a/tests/tests/test_devices.py
+++ b/tests/tests/test_devices.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import os
+from pathlib import Path
+
+import pytest
+
+import cli
+from common import single_user, expect_output, DEFAULT_TOKEN_PATH
+import api
+import docker
+import crypto
+
+
+@pytest.fixture(scope="function")
+def logged_in_single_user(single_user):
+    c = cli.Cli()
+    r = c.run(
+        "login",
+        "--server",
+        "https://mender-api-gateway",
+        "--skip-verify",
+        "--username",
+        "user@tenant.com",
+        "--password",
+        "youcantguess",
+    )
+
+    assert r.returncode == 0, r.stderr
+    yield
+    os.remove(DEFAULT_TOKEN_PATH)
+
+
+@pytest.fixture(scope="function")
+def clean_devauth_db():
+    yield
+    r = docker.exec(
+        "mender-mongo",
+        docker.BASE_COMPOSE_FILES,
+        "mongo",
+        "deviceauth",
+        "--eval",
+        "db.dropDatabase()",
+    )
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.usefixtures("clean_devauth_db")
+class TestDevicesList:
+    def test_ok(self, logged_in_single_user):
+        # Create a device
+        authset = crypto.rand_id_data()
+        keypair = crypto.get_keypair_rsa()
+        dapi = api.DevicesDevauth()
+        r = dapi.post_auth_request(authset, keypair[1], keypair[0])
+        assert r.status_code == 401
+
+        # Device should be listed as pending
+        c = cli.Cli()
+        r = c.run(
+            "--server", "https://mender-api-gateway", "--skip-verify", "devices", "list"
+        )
+        assert r.returncode == 0, r.stderr
+        expect_output(r.stdout, "Status: pending")
+
+        # Get and accept the device
+        token = Path(DEFAULT_TOKEN_PATH).read_text()
+        mapi = api.ManagementDevauth(token)
+        r = mapi.get_devices()
+        assert r.status_code == 200
+        devices = r.json()
+        device_id = devices[0]["id"]
+        authset_id = devices[0]["auth_sets"][0]["id"]
+        r = mapi.set_device_auth_status(device_id, authset_id, "accepted")
+        assert r.status_code == 204
+
+        # Device should now be listed as accepted
+        c = cli.Cli()
+        r = c.run(
+            "--server", "https://mender-api-gateway", "--skip-verify", "devices", "list"
+        )
+        assert r.returncode == 0, r.stderr
+        expect_output(r.stdout, "Status: accepted")


### PR DESCRIPTION
* New command devices list
Fixed minor details in existing code for coherence. Adding acceptance
tests also.
Changelog: New command `mender-cli devices list` to list all devices
from /devauth/devices endpoint. The amount of detail can be controlled
using cli parameter `-d/--detail`, same as for other commands.

* [http clients code] Refactor common code into common.go