### PR TITLE
Test fix and misc clean-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ build-acceptance-tools:
 		echo "aborting: PROJECT_DIR not set";\
 	    exit 1;\
 	 fi
-	wget -q -O ${PROJECT_DIR}/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/mender-artifact
+	wget -q -O ${PROJECT_DIR}/mender-artifact https://downloads.mender.io/mender-artifact/master/mender-artifact
 	chmod +x ${PROJECT_DIR}/mender-artifact
 
 build-acceptance-image:

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ get-go-tools:
 
 get-build-deps:
 	apt-get update -qq
-	apt-get install -yyq $(cat deb-requirements.txt);
+	apt-get install -yyq $(shell cat deb-requirements.txt)
 
 get-deps: get-go-tools get-build-deps
 

--- a/tests/tests/common.py
+++ b/tests/tests/common.py
@@ -22,7 +22,7 @@ import docker
 USER_HOME = str(Path.home())
 DEFAULT_TOKEN_PATH = os.path.join(USER_HOME,'.cache', 'mender', 'authtoken')
 
-@pytest.yield_fixture(scope="class")
+@pytest.fixture(scope="class")
 def single_user():
     r = docker.exec('mender-useradm', \
                     docker.BASE_COMPOSE_FILES, \

--- a/tests/tests/common.py
+++ b/tests/tests/common.py
@@ -44,5 +44,5 @@ def clean_useradm_db():
     assert r.returncode == 0, r.stderr
 
 def expect_output(stream, *expected):
-        for e in expected:
-            assert e in stream, 'expected string {} not found in stream'.format(e)
+    for e in expected:
+        assert e in stream, f'expected string "{e}" not found in stream: {stream}'

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -25,7 +25,7 @@ import docker
 import s3
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def logged_in_single_user(single_user):
     c = cli.Cli()
     r = c.run('login', \
@@ -39,14 +39,14 @@ def logged_in_single_user(single_user):
     os.remove(DEFAULT_TOKEN_PATH)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def valid_artifact():
     path = '/tests/foo-artifact'
     artifact.create_artifact_file(path)
     yield path
     os.remove(path)
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def clean_deployments_db():
     yield
     r = docker.exec('mender-mongo', \
@@ -54,7 +54,7 @@ def clean_deployments_db():
                     'mongo', 'deployment_service', '--eval', 'db.dropDatabase()')
     assert r.returncode == 0, r.stderr
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def clean_mender_storage():
     yield
     s3.cleanup_mender_storage()

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -49,9 +49,10 @@ def valid_artifact():
 @pytest.yield_fixture(scope="function")
 def clean_deployments_db():
     yield
-    r = docker.exec('mender-mongo-deployments', \
+    r = docker.exec('mender-mongo', \
                     docker.BASE_COMPOSE_FILES, \
                     'mongo', 'deployment_service', '--eval', 'db.dropDatabase()')
+    assert r.returncode == 0, r.stderr
 
 @pytest.yield_fixture(scope="function")
 def clean_mender_storage():

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -117,7 +117,7 @@ class TestLogin:
         with open(os.getenv("HOME") + "/.mender-clirc", "w") as f:
             try:
                 f.write(conf)
-            except Expeception as e:
+            except Exception as e:
                 pytest.fail("Failed to create configuration file: {}".format(e))
 
     def test_login_from_configuration_file(self, single_user):

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -20,7 +20,7 @@ from common import single_user, expect_output, DEFAULT_TOKEN_PATH
 import cli
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def cleanup_token(request):
     yield
     os.remove(request.param)


### PR DESCRIPTION
* [tests] Correct service name in fixture
This has been wrong for a very long time, but the fixture was not
asserting on the return code, so it went unnoticed.
* [Makefile] Download mender-artifact from new location
* [tests] Replace deprecated yield_fixture with fixture
To clear the warnings printed by pytest. They do the same.