### PR TITLE
QA-256: Collect and publish acceptance tests coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,21 +74,21 @@ test:unit:
   image: golang:1.15
 
 test_acceptance_build:tools:
-  image: alpine
   stage: test_acceptance_build
   dependencies:
     - compile
   script:
-    - apk add --no-cache make
     # make target env var
     - export PROJECT_DIR="$CI_PROJECT_DIR/"
     - cp mender-cli.linux.amd64 $CI_PROJECT_DIR/mender-cli
     - make build-acceptance-tools
+    - make build-coverage
   artifacts:
     untracked: true
     paths:
       - mender-cli
       - mender-artifact
+      - mender-cli-test
 
 test_acceptance_build:image:
   stage: test_acceptance_build
@@ -119,8 +119,43 @@ test_acceptance:run:
     # make target env var
     - export SHARED_PATH="$(dirname ${CI_PROJECT_DIR})/shared"
     - make run-acceptance
+    - tar -cvf $CI_PROJECT_DIR/acceptance-coverage.tar -C ${SHARED_PATH} cover
   tags:
     - docker
+  artifacts:
+    expire_in: 2w
+    paths:
+      - acceptance-coverage.tar
+
+
+publish:acceptance:
+  stage: publish
+  image: golang:1.14-alpine3.11
+  dependencies:
+    - test_acceptance:run
+  before_script:
+    - apk add --no-cache git
+    # Run go get out of the repo to not modify go.mod
+    - cd / && go get github.com/mattn/goveralls && cd -
+    # Coveralls env variables:
+    #  According to https://docs.coveralls.io/supported-ci-services
+    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
+    #  to goveralls source code (https://github.com/mattn/goveralls)
+    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
+    #  and pass few others as command line arguments.
+    #  See also https://docs.coveralls.io/api-reference
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
+    - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
+  script:
+    - tar -xvf acceptance-coverage.tar
+    - goveralls
+      -repotoken ${COVERALLS_TOKEN}
+      -service gitlab-ci
+      -jobid $(git rev-parse HEAD)
+      -covermode set
+      -flagname acceptance
+      -parallel
+      -coverprofile $(find cover -type f | tr '\n' ',' | sed 's/,$//')
 
 publish:s3:
   stage: publish

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ build-multiplatform:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) \
 	     -o mender-cli.darwin.amd64
 
+build-coverage:
+	CGO_ENABLED=0 $(GO) test -c -o mender-cli-test \
+		-coverpkg $(shell echo $(PKGS) | tr  ' ' ',')
+
 install:
 	CGO_ENABLED=0 $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
@@ -92,7 +96,7 @@ run-acceptance:
 	    exit 1;\
 	 fi
 	mkdir -p ${SHARED_PATH}
-	cp -r mender-artifact mender-cli tests/* ${SHARED_PATH}
+	cp -r mender-artifact mender-cli mender-cli-test tests/* ${SHARED_PATH}
 	git clone -b master https://github.com/mendersoftware/integration.git ${SHARED_PATH}/integration
 	# this is basically https://github.com/mendersoftware/integration/blob/master/tests/run.sh#L51
 	# to allow the tests to be run, as the composition is now generated during test image build

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mendersoftware/mender-cli/cmd"
+)
+
+var runAcceptanceTests bool
+
+// used for parsing '-cli-args' for urfave/cli when running acceptance tests
+// this is because of a conflict between urfave/cli and regular go flags required for testing (can't mix the two)
+var cliArgsRaw string
+
+func init() {
+	flag.BoolVar(&runAcceptanceTests, "acceptance-tests", false, "set flag when running acceptance tests")
+	flag.StringVar(&cliArgsRaw, "cli-args", "", "for passing urfave/cli args (single string) when golang flags are specified (avoids conflict)")
+}
+
+func TestMain(t *testing.T) {
+	flag.Parse()
+	if !runAcceptanceTests {
+		t.Skip()
+	}
+
+	// parse '-cli-args', remember about binary name at idx 0
+	var cliArgs []string
+
+	if cliArgsRaw != "" {
+		cliArgs = []string{os.Args[0]}
+		splitArgs := strings.Split(cliArgsRaw, " ")
+		cliArgs = append(cliArgs, splitArgs...)
+	}
+
+	os.Args = cliArgs
+
+	cmd.Execute()
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,6 +4,8 @@ DIR=$(readlink -f $(dirname $0))
 
 [ $$ -eq 1 ] && sleep 10
 
+mkdir -p /tests/cover
+
 py.test -s --tb=short \
           --verbose --junitxml=$DIR/results.xml \
           $DIR/tests/test_*.py "$@"

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -62,7 +62,7 @@ def clean_mender_storage():
 class TestArtifactUpload:
     @pytest.mark.usefixtures('clean_deployments_db', 'clean_mender_storage')
     def test_ok(self, logged_in_single_user, valid_artifact):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
         r = c.run('--server', 'https://mender-api-gateway', \
                   '--skip-verify', \
                   'artifacts', 'upload', \
@@ -89,7 +89,7 @@ class TestArtifactUpload:
         assert artifact['device_types_compatible'] == ['device-foo']
 
     def test_error_no_login(self, valid_artifact):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
         r = c.run('--server', 'https://mender-api-gateway', \
                   '--skip-verify', \
                   'artifacts', 'upload', \

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -29,7 +29,7 @@ def cleanup_token(request):
 class TestLogin:
     @pytest.mark.parametrize("cleanup_token", [DEFAULT_TOKEN_PATH], indirect=True)
     def test_ok(self, single_user, cleanup_token):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
 
         r = c.run(
             "login",
@@ -49,7 +49,7 @@ class TestLogin:
 
     @pytest.mark.parametrize("cleanup_token", ["/tests/authtoken"], indirect=True)
     def test_ok_custom_path(self, single_user, cleanup_token):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
 
         custom_path = "/tests/authtoken"
 
@@ -73,7 +73,7 @@ class TestLogin:
 
     @pytest.mark.parametrize("cleanup_token", [DEFAULT_TOKEN_PATH], indirect=True)
     def test_ok_verbose(self, single_user, cleanup_token):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
 
         r = c.run(
             "login",
@@ -95,7 +95,7 @@ class TestLogin:
         )
 
     def test_error_wrong_creds(self, single_user):
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
 
         r = c.run(
             "login",
@@ -133,7 +133,7 @@ class TestLogin:
 
         self._write_mender_cli_conf(conf)
 
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
         r = c.run("login", "--skip-verify")
 
         assert r.returncode != 0, r.stderr
@@ -183,7 +183,7 @@ class TestLogin:
 
         self._write_mender_cli_conf(conf)
 
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
         r = c.run_and_enter_password("login", "--skip-verify", password="youcantguess")
 
         assert r.returncode == 0, r.stderr
@@ -206,7 +206,7 @@ class TestLogin:
 
         self._write_mender_cli_conf(conf)
 
-        c = cli.Cli()
+        c = cli.MenderCliCoverage()
         r = c.run(
             "login",
             "--server",


### PR DESCRIPTION
Namely:
* New TestMain to parse flags and call actual main (inspired in backend
  services design).
* New make target to compile the binary with coverage instrumentation.
* Test wrapper to use the instrumented binary on cli calls, creating
  unique coverage filenames.
* Extend pipeline to collect and publish the coverage stats.