### PR TITLE
Cherry1.5: Fix: Respect the --server flag from config everywhere

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ test:acceptance:
     - git clone -b master https://github.com/mendersoftware/integration.git ${SHARED_PATH}/integration
     # this is basically https://github.com/mendersoftware/integration/blob/master/tests/run.sh#L51
     # to allow the tests to be run, as the composition is now generated during test image build
-    - sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/ports:/d' ${SHARED_PATH}/integration/docker-compose.demo.yml > ${SHARED_PATH}/integration/docker-compose.testing.yml
+    - sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/80:80/d' -e '/443:443/d' -e '/ports:/d' ${SHARED_PATH}/integration/docker-compose.demo.yml > ${SHARED_PATH}/integration/docker-compose.testing.yml
     - sed -e 's/DOWNLOAD_SPEED/#DOWNLOAD_SPEED/' -i ${SHARED_PATH}/integration/docker-compose.testing.yml
     - sed -e 's/ALLOWED_HOSTS:\ .*/ALLOWED_HOSTS:\ _/' -i ${SHARED_PATH}/integration/docker-compose.testing.yml
     - TESTS_DIR=${SHARED_PATH} ${SHARED_PATH}/integration/extra/travis-testing/run-test-environment acceptance ${SHARED_PATH}/integration ${SHARED_PATH}/docker-compose.acceptance.yml ;

--- a/cmd/artifact_upload.go
+++ b/cmd/artifact_upload.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/mendersoftware/mender-cli/client/deployments"
 	"github.com/mendersoftware/mender-cli/log"
@@ -52,9 +55,9 @@ type ArtifactUploadCmd struct {
 }
 
 func NewArtifactUploadCmd(cmd *cobra.Command, args []string) (*ArtifactUploadCmd, error) {
-	server, err := cmd.Flags().GetString(argRootServer)
-	if err != nil {
-		return nil, err
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("No server")
 	}
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -50,20 +50,8 @@ func init() {
 
 	loginCmd.Flags().StringP(argLoginPassword, "", "", "password (will prompt if not provided)")
 	loginCmd.Flags().StringP(argLoginToken, "", "", "two-factor authentication token")
-
-	viper.SetConfigName(".mender-clirc")
-	viper.SetConfigType("json")
-	viper.AddConfigPath("/etc/mender-cli/")
-	viper.AddConfigPath("$HOME/")
-	viper.AddConfigPath(".")
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			log.Info(fmt.Sprintf("Failed to read config: %s", err))
-			os.Exit(1)
-		}
-	} else {
-		log.Info(fmt.Sprintf("Using configuration file: %s", viper.ConfigFileUsed()))
-	}
+	viper.BindPFlag(argLoginUsername, loginCmd.Flags().Lookup(argLoginUsername))
+	viper.BindPFlag(argLoginPassword, loginCmd.Flags().Lookup(argLoginPassword))
 }
 
 type LoginCmd struct {
@@ -76,9 +64,6 @@ type LoginCmd struct {
 }
 
 func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
-	viper.BindPFlag(argRootServer, cmd.Flags().Lookup(argRootServer))
-	viper.BindPFlag(argLoginUsername, cmd.Flags().Lookup(argLoginUsername))
-	viper.BindPFlag(argLoginPassword, cmd.Flags().Lookup(argLoginPassword))
 	server := viper.GetString(argRootServer)
 	if server == "" {
 		return nil, errors.New("No server, this should not happen")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/mendersoftware/mender-cli/log"
 )
@@ -29,6 +30,24 @@ const (
 	argRootVerbose    = "verbose"
 	argRootGenerate   = "generate-autocomplete"
 )
+
+func init() {
+	viper.SetConfigName(".mender-clirc")
+	viper.SetConfigType("json")
+	viper.AddConfigPath("/etc/mender-cli/")
+	viper.AddConfigPath("$HOME/")
+	viper.AddConfigPath(".")
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			log.Info(fmt.Sprintf("Failed to read config: %s", err))
+			os.Exit(1)
+		} else {
+			log.Info("Configuration file not found. Continuing.")
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Using configuration file: %s\n", viper.ConfigFileUsed())
+	}
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -66,6 +85,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringP(argRootServer, "", "https://hosted.mender.io", "root server URL, e.g. 'https://hosted.mender.io'")
+	viper.BindPFlag(argRootServer, rootCmd.PersistentFlags().Lookup(argRootServer))
 	rootCmd.PersistentFlags().BoolP(argRootSkipVerify, "k", false, "skip SSL certificate verification")
 	rootCmd.PersistentFlags().StringP(argRootToken, "", "", "token file path")
 	rootCmd.PersistentFlags().BoolP(argRootVerbose, "v", false, "print verbose output")

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -8,7 +8,6 @@ services:
             - mender-useradm
             - mender-api-gateway
             - mender-deployments
-            - storage-proxy
         volumes:
             - "${TESTS_DIR}:/tests"
             - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/tests/common.py
+++ b/tests/tests/common.py
@@ -22,7 +22,7 @@ import docker
 USER_HOME = str(Path.home())
 DEFAULT_TOKEN_PATH = os.path.join(USER_HOME,'.cache', 'mender', 'authtoken')
 
-@pytest.yield_fixture(scope="class")
+@pytest.fixture(scope="class")
 def single_user():
     r = docker.exec('mender-useradm', \
                     docker.BASE_COMPOSE_FILES, \

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -25,7 +25,7 @@ import docker
 import s3
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def logged_in_single_user(single_user):
     c = cli.Cli()
     r = c.run('login', \
@@ -39,21 +39,21 @@ def logged_in_single_user(single_user):
     os.remove(DEFAULT_TOKEN_PATH)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def valid_artifact():
     path = '/tests/foo-artifact'
     artifact.create_artifact_file(path)
     yield path
     os.remove(path)
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def clean_deployments_db():
     yield
     r = docker.exec('mender-mongo-deployments', \
                     docker.BASE_COMPOSE_FILES, \
                     'mongo', 'deployment_service', '--eval', 'db.dropDatabase()')
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def clean_mender_storage():
     yield
     s3.cleanup_mender_storage()

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -117,7 +117,7 @@ class TestLogin:
         with open(os.getenv("HOME") + "/.mender-clirc", "w") as f:
             try:
                 f.write(conf)
-            except Expeception as e:
+            except Exception as e:
                 pytest.fail("Failed to create configuration file: {}".format(e))
 
     def test_login_from_configuration_file(self, single_user):

--- a/tests/tests/test_login.py
+++ b/tests/tests/test_login.py
@@ -20,7 +20,7 @@ from common import single_user, expect_output, DEFAULT_TOKEN_PATH
 import cli
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def cleanup_token(request):
     yield
     os.remove(request.param)


### PR DESCRIPTION
Previously, the configuration --server flag was only bound to the configuration
file value in the login command.

By moving the viper configuration to the root command, and fetching the value
from viper everywhere, the flag is now properly handled everywhere.

Changelog: Title
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 6a814cd889b037f04c250b332d8360f53c7739d2)