### PR TITLE
1.4.x: pipeline fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ test:acceptance:
     - docker load -i acceptance_testing_image.tar
     - export SHARED_PATH="$(dirname ${CI_PROJECT_DIR})/shared"
     - mkdir -p ${SHARED_PATH} && mv mender-artifact mender-cli tests/* ${SHARED_PATH}
-    - git clone -b master https://github.com/mendersoftware/integration.git ${SHARED_PATH}/integration
+    - git clone -b 2.4.x https://github.com/mendersoftware/integration.git ${SHARED_PATH}/integration
     # this is basically https://github.com/mendersoftware/integration/blob/master/tests/run.sh#L51
     # to allow the tests to be run, as the composition is now generated during test image build
     - sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/ports:/d' ${SHARED_PATH}/integration/docker-compose.demo.yml > ${SHARED_PATH}/integration/docker-compose.testing.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ before_script:
   - mkdir -p /go/src/$(dirname $REPO_NAME)/mender-cli /go/src/_/builds
   - cp -r $CI_PROJECT_DIR /go/src/$(dirname $REPO_NAME)
   - cd /go/src/$(dirname $REPO_NAME)/mender-cli
-  - apt-get update && apt-get install -yyq liblzma-dev
 
 stages:
   - test_prep


### PR DESCRIPTION
* [pipeline] Remove unnecessary dependency liblzma
This call was actually silently failing with `apt-get: not found`. And
in any case it is not needed for mender-cli.

* [pipeline] Fix acceptance tests
By checking out corresponding branch of integration repo (2.4.x) instead
of master.
Fixes error:
```
Service 'acceptance' depends on service 'storage-proxy' which is undefined.
```