### PR TITLE
Raw mode for devices list command

### DIFF
--- a/client/devices/client.go
+++ b/client/devices/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ func NewClient(url string, skipVerify bool) *Client {
 	}
 }
 
-func (c *Client) ListDevices(tokenPath string, detailLevel int) error {
+func (c *Client) ListDevices(tokenPath string, detailLevel int, raw bool) error {
 	if detailLevel > 3 || detailLevel < 0 {
 		return fmt.Errorf("FAILURE: invalid devices detail")
 	}
@@ -77,15 +77,19 @@ func (c *Client) ListDevices(tokenPath string, detailLevel int) error {
 		return err
 	}
 
-	var list devicesList
-	err = json.Unmarshal(body, &list.devices)
-	if err != nil {
-		return err
-	}
-	for _, v := range list.devices {
-		listDevice(v, detailLevel)
-	}
+	if raw {
+		print(string(body))
+	} else {
 
+		var list devicesList
+		err = json.Unmarshal(body, &list.devices)
+		if err != nil {
+			return err
+		}
+		for _, v := range list.devices {
+			listDevice(v, detailLevel)
+		}
+	}
 	return nil
 }
 

--- a/cmd/devices_list.go
+++ b/cmd/devices_list.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -32,8 +32,15 @@ var devicesListCmd = &cobra.Command{
 	},
 }
 
+const argRawMode = "raw"
+
 func init() {
 	devicesListCmd.Flags().IntP(argDetailLevel, "d", 0, "devices list detail level [0..3]")
+	devicesListCmd.Flags().BoolP(
+		argRawMode,
+		"r",
+		false,
+		"devices list raw mode (json from mender server)")
 }
 
 type DevicesListCmd struct {
@@ -41,6 +48,7 @@ type DevicesListCmd struct {
 	skipVerify  bool
 	tokenPath   string
 	detailLevel int
+	rawMode     bool
 }
 
 func NewDevicesListCmd(cmd *cobra.Command, args []string) (*DevicesListCmd, error) {
@@ -64,6 +72,11 @@ func NewDevicesListCmd(cmd *cobra.Command, args []string) (*DevicesListCmd, erro
 		return nil, err
 	}
 
+	rawMode, err := cmd.Flags().GetBool(argRawMode)
+	if err != nil {
+		return nil, err
+	}
+
 	if token == "" {
 		token, err = getDefaultAuthTokenPath()
 		if err != nil {
@@ -76,11 +89,12 @@ func NewDevicesListCmd(cmd *cobra.Command, args []string) (*DevicesListCmd, erro
 		tokenPath:   token,
 		skipVerify:  skipVerify,
 		detailLevel: detailLevel,
+		rawMode:     rawMode,
 	}, nil
 }
 
 func (c *DevicesListCmd) Run() error {
 
 	client := devices.NewClient(c.server, c.skipVerify)
-	return client.ListDevices(c.tokenPath, c.detailLevel)
+	return client.ListDevices(c.tokenPath, c.detailLevel, c.rawMode)
 }


### PR DESCRIPTION
Add a new flag to enable raw mode for device list command. This helps if
the output is processed further in scripts, ...

Changelog: Title

Signed-off-by: Ruben Schwarz <r.schwarz@sotec.eu>