### PR TITLE
MEN-5725: Small usability and error output improvement

### DIFF
--- a/client/deployments/client.go
+++ b/client/deployments/client.go
@@ -233,16 +233,12 @@ func (c *Client) UploadArtifact(
 	log.Verbf("response: \n%v\n", string(rspDump))
 
 	if rsp.StatusCode != http.StatusCreated {
-		body, err := ioutil.ReadAll(rsp.Body)
-		if err != nil {
-			return errors.Wrap(err, "can't read request body")
-		}
 		if rsp.StatusCode == http.StatusUnauthorized {
-			log.Verbf("artifact upload failed with status %d, reason: %s", rsp.StatusCode, body)
+			log.Verbf("artifact upload to '%s' failed with status %d", req.Host, rsp.StatusCode)
 			return errors.New("Unauthorized. Please Login first")
 		}
 		return errors.New(
-			fmt.Sprintf("artifact upload failed with status %d, reason: %s", rsp.StatusCode, body),
+			fmt.Sprintf("artifact upload to '%s' failed with status %d", req.Host, rsp.StatusCode),
 		)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -100,6 +101,15 @@ func Execute() {
 	CheckErr(rootCmd.Execute())
 }
 
+func validateConfiguration() {
+	server := viper.GetString(argRootServer)
+	u, _ := url.Parse(server)
+	if u.Scheme == "" {
+		viper.Set(argRootServer, "https://"+server)
+		log.Info("Protocol is not specified, HTTPS is used by default.")
+	}
+}
+
 func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -126,4 +136,5 @@ func init() {
 	rootCmd.AddCommand(terminalCmd)
 	rootCmd.AddCommand(portForwardCmd)
 	rootCmd.AddCommand(fileTransferCmd)
+	validateConfiguration()
 }


### PR DESCRIPTION
Changelog: None
Ticket: MEN-5725
Signed-off-by: Alex Miliukov <oleksandr.miliukov@northern.tech>

The change also makes configuration more user friendly by adding protocol automatically. Currently, when `"server": "hosted.mender.io"`, artifact upload fails with 401 `authorization not present in header` error, which is misleading.