### PR TITLE
QA-507: ci: pin acceptance tests image to Alpine 3.16

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,5 @@
-FROM tiangolo/docker-with-compose
+# QA-507: Pin to Alpine 3.16 to have OpenSSL 1.1 compatibility while we redesign this dependency
+FROM tiangolo/docker-with-compose:2022-11-28
 
 RUN apk add bash python3 libc6-compat xz-dev
 RUN pip3 install requests minio pytest


### PR DESCRIPTION
To workaround the issue with openssl 3 upgrade in latest Alpine.

We are working on a plan to upgrade the whole ecosystem, but meanwhile we need to pin these jobs to older Alpine to keep CI running.

Changelog: None
Ticket: QA-507
Signed-off-by: Alex Miliukov <oleksandr.miliukov@northern.tech>