### PR TITLE
fix(portforward): allow to get the server from mender-clirc configura…

### DIFF
--- a/cmd/portforward.go
+++ b/cmd/portforward.go
@@ -28,6 +28,7 @@ import (
 	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vmihailenco/msgpack"
 	"golang.org/x/sys/unix"
 
@@ -151,9 +152,9 @@ func getPortMappings(args []string) ([]portMapping, error) {
 
 // NewPortForwardCmd returns a new PortForwardCmd
 func NewPortForwardCmd(cmd *cobra.Command, args []string) (*PortForwardCmd, error) {
-	server, err := cmd.Flags().GetString(argRootServer)
-	if err != nil {
-		return nil, err
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("No server")
 	}
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)


### PR DESCRIPTION
…tion file

At the moment portforward doesn't take into account the mender clirc configuration file.

Duplicate what's is done in mender terminal to get the proper configuration.

Changelog: Title
Ticket: None

Signed-off-by: Clément Péron <peron.clem@gmail.com>
(cherry picked from commit a0d6c05c7cbfa765e8cb74c6d74ab9522d951db3)