### PR TITLE
Added SSL certificates to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ WORKDIR /go/src/github.com/mendersoftware/mender-cli
 ADD ./ .
 RUN make build
 
+FROM alpine as certs
+RUN apk update && apk add ca-certificates
+
 FROM busybox
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /go/src/github.com/mendersoftware/mender-cli/mender-cli /
 ENTRYPOINT ["/mender-cli"]


### PR DESCRIPTION
`./mender-cli login` failed with

     FAILURE: POST /auth/login request failed: Post "https://hosted.mender.io/api/management/v1/useradm/auth/login": x509: certificate signed by unknown authority

Adding `ca-certificates` fixed the issue