### PR TITLE
fix: List devices in raw mode not in stdout

### DIFF
--- a/client/devices/client.go
+++ b/client/devices/client.go
@@ -78,7 +78,7 @@ func (c *Client) ListDevices(token string, detailLevel int, raw bool) error {
 	}
 
 	if raw {
-		print(string(body))
+		fmt.Println(string(body))
 	} else {
 
 		var list devicesList


### PR DESCRIPTION
Printing the list of devices with flag -r was not directed to stdout but stderr.

Ticket: None
Changelog: Title