### PR TITLE
ci: move from public to self-hosted runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ test_acceptance:run:
     - make run-acceptance
     - tar -cvf $CI_PROJECT_DIR/acceptance-coverage.tar -C ${SHARED_PATH} cover
   tags:
-    - docker
+    - hetzner-amd-beefy
   artifacts:
     expire_in: 2w
     paths:


### PR DESCRIPTION
Public runners are considered not secure; moving to self-hosted runners instead. Additionally, the docker runner tag is no longer available.

Ticket: SEC-1133
Changelog: None