### PR TITLE
test(fix): move to docker compose instead of docker-compose.

### DIFF
--- a/tests/tests/docker.py
+++ b/tests/tests/docker.py
@@ -21,10 +21,10 @@ BASE_COMPOSE_FILES = [
 ]
 
 def exec(service, files, *argv):
-    c = cli.Cli('/usr/bin/docker-compose')
+    c = cli.Cli('docker')
 
     # set by run-test-environment
-    args = ['-p', 'acceptance-tests']
+    args = ['compose', '-p', 'acceptance-tests']
 
     for f in files:
         args += ['-f', f]


### PR DESCRIPTION
test(fix): move to docker compose instead of docker-compose.

The docker-compose started to silently exit with return code 1.

Changelog: None
Ticket: None
Signed-off-by: Peter Grzybowski <peter@northern.tech>