### PR TITLE
chore: Use #mender-cli in the link to the Downloads page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To start using `mender-cli`, we recommend that you begin with the
 ## Downloading the binaries
 
 You can find the latest `mender-cli` binaries in the [Downloads page on Mender
-Docs](https://docs.mender.io/downloads).
+Docs](https://docs.mender.io/downloads#mender-cli).
 
 ## Configuration file
 


### PR DESCRIPTION
So that people don't have to search through the page.

Ticket: none
Changelog: none