### PR TITLE
feat: use paginated endpoint to list artifacts

### DIFF
--- a/cmd/devices_list.go
+++ b/cmd/devices_list.go
@@ -91,6 +91,10 @@ func NewDevicesListCmd(cmd *cobra.Command, args []string) (*DevicesListCmd, erro
 		return nil, err
 	}
 
+	if page <= 0 || perPage <= 0 {
+		return nil, errors.New("page and per-page arguments must be larger than 0")
+	}
+
 	token, err := getAuthToken(cmd)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Changelog: Use the new paginated API endpoint to list artifacts and add support for pagination to the `artifacts  list` command. Note that this is a breaking change as the current API does not support pagination and will always list all artifacts.

Ticket: MEN-8302