### PR TITLE
Revert "chore: update missing license"

### DIFF
--- a/licenses.csv
+++ b/licenses.csv
@@ -17,7 +17,6 @@ github.com/mattn/go-runewidth,MIT
 github.com/minio/sha256-simd,Apache-2.0
 github.com/pelletier/go-toml/v2,MIT
 github.com/pkg/errors,BSD-2-Clause
-github.com/remyoudompheng/go-liblzma,BSD-3-Clause
 github.com/rivo/uniseg,MIT
 github.com/sagikazarmark/locafero,MIT
 github.com/sourcegraph/conc,MIT


### PR DESCRIPTION
This reverts commit fc6b64a139e04ddc04c0919d4341819addb029a8.

Ticket: None
Changelog: None