### PR TITLE
ci: allow coveralls publish to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,8 @@ test:install:brew:
 
 publish:acceptance:
   stage: publish
-  image: golang:1.20-alpine3.17
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:1.20-alpine3.17
+  allow_failure: true # QA-925 - Coveralls servers are unreliable.
   dependencies:
     - test_acceptance:run
   before_script:


### PR DESCRIPTION
Because coveralls servers are unreliable

Ticket: QA-1232