### PR TITLE
fix: concurrent map access for mutexes for in-flight messages

### DIFF
--- a/cmd/portforward.go
+++ b/cmd/portforward.go
@@ -21,8 +21,10 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mendersoftware/go-lib-micro/ws"
 	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
 	"github.com/pkg/errors"
@@ -94,7 +96,8 @@ type PortForwardCmd struct {
 	sessionID    string
 	bindingHost  string
 	portMappings []portMapping
-	recvChans    map[string]chan *ws.ProtoMsg
+	recvChanMu   sync.RWMutex
+	recvChans    map[string]chan<- *ws.ProtoMsg
 	running      bool
 	stop         chan struct{}
 	err          error
@@ -184,7 +187,7 @@ func NewPortForwardCmd(cmd *cobra.Command, args []string) (*PortForwardCmd, erro
 		deviceID:     args[0],
 		bindingHost:  bindingHost,
 		portMappings: portMappings,
-		recvChans:    make(map[string]chan *ws.ProtoMsg),
+		recvChans:    make(map[string]chan<- *ws.ProtoMsg),
 		stop:         make(chan struct{}),
 	}, nil
 }
@@ -196,6 +199,24 @@ func (c *PortForwardCmd) Run() error {
 			return err
 		}
 	}
+}
+
+func (c *PortForwardCmd) registerRecvChan(recvChan chan<- *ws.ProtoMsg) string {
+	c.recvChanMu.Lock()
+	defer c.recvChanMu.Unlock()
+	for range 3 {
+		connectionID := uuid.NewString()
+		if _, ok := c.recvChans[connectionID]; ok {
+			continue
+		} else {
+			c.recvChans[connectionID] = recvChan
+			return connectionID
+		}
+	}
+	panic(`Congratulations!
+You just encountered a tripple UUID v4 collision.
+Either your computer is exceptionally bad at coming up with random numbers,
+or you're just that one in a hundred million googols. 💎`)
 }
 
 func (c *PortForwardCmd) run() error {
@@ -239,14 +260,14 @@ func (c *PortForwardCmd) run() error {
 			if err != nil {
 				return err
 			}
-			go forwarder.Run(ctx, c.sessionID, msgChan, c.recvChans)
+			go forwarder.Run(ctx, c.sessionID, msgChan, c.registerRecvChan)
 		case protocolUDP:
 			forwarder, err := NewUDPPortForwarder(c.bindingHost, portMapping.LocalPort,
 				portMapping.RemoteHost, portMapping.RemotePort)
 			if err != nil {
 				return err
 			}
-			go forwarder.Run(ctx, c.sessionID, msgChan, c.recvChans)
+			go forwarder.Run(ctx, c.sessionID, msgChan, c.registerRecvChan)
 		default:
 			return errors.New("unknown protocol: " + portMapping.Protocol)
 		}
@@ -411,7 +432,10 @@ func (c *PortForwardCmd) processIncomingMessages(
 				m.Header.MsgType == wspf.MessageTypePortForwardStop) {
 			connectionID, _ := m.Header.Properties[wspf.PropertyConnectionID].(string)
 			if connectionID != "" {
-				if recvChan, ok := c.recvChans[connectionID]; ok {
+				c.recvChanMu.RLock()
+				recvChan, ok := c.recvChans[connectionID]
+				c.recvChanMu.RUnlock()
+				if ok {
 					recvChan <- m
 				}
 			}

--- a/cmd/portforward_tcp.go
+++ b/cmd/portforward_tcp.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/mendersoftware/go-lib-micro/ws"
 	"github.com/mendersoftware/go-lib-micro/ws/portforward"
 	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
@@ -60,7 +59,7 @@ func (p *TCPPortForwarder) Run(
 	ctx context.Context,
 	sessionID string,
 	msgChan chan *ws.ProtoMsg,
-	recvChans map[string]chan *ws.ProtoMsg,
+	registerRecvChan func(chan<- *ws.ProtoMsg) string,
 ) {
 	// listen for new connections
 	defer p.listen.Close()
@@ -98,10 +97,8 @@ func (p *TCPPortForwarder) Run(
 			if !open {
 				return
 			}
-			connectionUUID, _ := uuid.NewUUID()
-			connectionID := connectionUUID.String()
 			recvChan := make(chan *ws.ProtoMsg, portForwardTCPChannelSize)
-			recvChans[connectionID] = recvChan
+			connectionID := registerRecvChan(recvChan)
 			go p.handleRequest(ctx, conn, sessionID, connectionID, recvChan, msgChan)
 		case <-ctx.Done():
 			return
@@ -135,8 +132,15 @@ func (p *TCPPortForwarder) handleInboundMessages(
 	}()
 
 	for {
+		var (
+			m    *ws.ProtoMsg
+			open bool
+		)
 		select {
-		case m := <-recvChan:
+		case m, open = <-recvChan:
+			if !open {
+				return
+			}
 			if m.Header.Proto == ws.ProtoTypePortForward &&
 				m.Header.MsgType == wspf.MessageTypePortForwardStop {
 				sendStopMessage = false
@@ -145,12 +149,13 @@ func (p *TCPPortForwarder) handleInboundMessages(
 				m.Header.MsgType == wspf.MessageTypePortForward {
 				_, err := conn.Write(m.Body)
 				if err != nil {
-					if errors.Unwrap(err) != net.ErrClosed {
+					if !errors.Is(err, net.ErrClosed) {
 						fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
 					}
+					return
 				} else {
 					// send the ack
-					m := &ws.ProtoMsg{
+					m = &ws.ProtoMsg{
 						Header: ws.ProtoHdr{
 							Proto:     ws.ProtoTypePortForward,
 							MsgType:   wspf.MessageTypePortForwardAck,
@@ -164,7 +169,10 @@ func (p *TCPPortForwarder) handleInboundMessages(
 				}
 			} else if m.Header.Proto == ws.ProtoTypePortForward &&
 				m.Header.MsgType == wspf.MessageTypePortForwardAck {
-				<-ackChan
+				_, open = <-ackChan
+				if !open {
+					return
+				}
 			}
 		case <-ctx.Done():
 			return

--- a/cmd/portforward_udp.go
+++ b/cmd/portforward_udp.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/mendersoftware/go-lib-micro/ws"
 	"github.com/mendersoftware/go-lib-micro/ws/portforward"
 	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
@@ -73,15 +72,13 @@ func (p *UDPPortForwarder) Run(
 	ctx context.Context,
 	sessionID string,
 	msgChan chan *ws.ProtoMsg,
-	recvChans map[string]chan *ws.ProtoMsg,
+	registerRecvChan func(chan<- *ws.ProtoMsg) string,
 ) {
 	// listen for new connections
 	defer p.conn.Close()
 
-	connectionUUID, _ := uuid.NewUUID()
-	connectionID := connectionUUID.String()
 	recvChan := make(chan *ws.ProtoMsg, portForwardUDPChannelSize)
-	recvChans[connectionID] = recvChan
+	connectionID := registerRecvChan(recvChan)
 
 	protocol := portforward.PortForwardProtocol(wspf.PortForwardProtocolUDP)
 	portforwardNew := &wspf.PortForwardNew{


### PR DESCRIPTION
This commit replaces the map with chan to better handle in flight messages while listening to concurrent events. This also solves the concurrency issue where the application crashes due to concurrent map writes.