### PR TITLE
feat: implement port-forwarding protocol v2

### DIFF
--- a/cmd/portforward.go
+++ b/cmd/portforward.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/mendersoftware/mender-cli/client/deviceconnect"
+	"github.com/mendersoftware/mender-cli/log"
 )
 
 const (
@@ -87,6 +89,7 @@ type portMapping struct {
 
 // PortForwardCmd handles the port-forward command
 type PortForwardCmd struct {
+	proto        ws.ProtoType
 	server       string
 	token        string
 	skipVerify   bool
@@ -235,14 +238,14 @@ func (c *PortForwardCmd) run() error {
 		switch portMapping.Protocol {
 		case protocolTCP:
 			forwarder, err := NewTCPPortForwarder(c.bindingHost, portMapping.LocalPort,
-				portMapping.RemoteHost, portMapping.RemotePort)
+				portMapping.RemoteHost, portMapping.RemotePort, c.proto)
 			if err != nil {
 				return err
 			}
 			go forwarder.Run(ctx, c.sessionID, msgChan, c.recvChans)
 		case protocolUDP:
 			forwarder, err := NewUDPPortForwarder(c.bindingHost, portMapping.LocalPort,
-				portMapping.RemoteHost, portMapping.RemotePort)
+				portMapping.RemoteHost, portMapping.RemotePort, c.proto)
 			if err != nil {
 				return err
 			}
@@ -268,8 +271,11 @@ func (c *PortForwardCmd) run() error {
 			err := client.WriteMessage(msg)
 			if err != nil {
 				c.err = err
-				break
+				c.running = false
 			}
+		case <-ctx.Done():
+			c.err = ctx.Err()
+			c.running = false
 		case <-time.After(time.Until(timeout)):
 			c.err = errors.New("port forward timed out: max duration reached")
 			c.running = false
@@ -342,15 +348,11 @@ func (c *PortForwardCmd) handshake(client *deviceconnect.Client) error {
 	if err != nil {
 		return err
 	}
-
-	found := false
-	for _, proto := range accept.Protocols {
-		if proto == ws.ProtoTypePortForward {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if slices.Contains(accept.Protocols, ws.ProtoTypePortForwardV2) {
+		c.proto = ws.ProtoTypePortForwardV2
+	} else if slices.Contains(accept.Protocols, ws.ProtoTypePortForward) {
+		c.proto = ws.ProtoTypePortForward
+	} else {
 		return errPortForwardNotImplemented
 	}
 
@@ -382,39 +384,70 @@ func (c *PortForwardCmd) processIncomingMessages(
 		m, err := client.ReadMessage()
 		if err != nil {
 			c.err = err
+			c.running = false
 			c.Stop()
 			break
-		} else if m.Header.Proto == ws.ProtoTypeControl && m.Header.MsgType == ws.MessageTypePing {
-			m := &ws.ProtoMsg{
-				Header: ws.ProtoHdr{
-					Proto:     ws.ProtoTypeControl,
-					MsgType:   ws.MessageTypePong,
-					SessionID: c.sessionID,
-				},
-			}
-			msgChan <- m
-		} else if m.Header.Proto == ws.ProtoTypePortForward &&
-			m.Header.MsgType == ws.MessageTypeError {
-			erro := new(ws.Error)
-			if err := msgpack.Unmarshal(m.Body, erro); err != nil &&
-				erro.MessageType != wspf.MessageTypePortForwardStop {
-				c.err = errors.New(fmt.Sprintf(
-					"Unable to start the port-forwarding: %s",
-					string(m.Body),
-				))
+		}
+		switch m.Header.Proto {
+		case ws.ProtoTypeControl:
+			if m.Header.MsgType == ws.MessageTypePing {
+				m := &ws.ProtoMsg{
+					Header: ws.ProtoHdr{
+						Proto:     ws.ProtoTypeControl,
+						MsgType:   ws.MessageTypePong,
+						SessionID: c.sessionID,
+					},
+				}
+				msgChan <- m
+			} else {
+				c.err = fmt.Errorf("invalid message type control/%s", m.Header.MsgType)
+				log.Err(c.err.Error())
 				c.running = false
 				c.Stop()
 			}
-		} else if m.Header.Proto == ws.ProtoTypePortForward &&
-			(m.Header.MsgType == wspf.MessageTypePortForward ||
-				m.Header.MsgType == wspf.MessageTypePortForwardAck ||
-				m.Header.MsgType == wspf.MessageTypePortForwardStop) {
-			connectionID, _ := m.Header.Properties[wspf.PropertyConnectionID].(string)
-			if connectionID != "" {
-				if recvChan, ok := c.recvChans[connectionID]; ok {
-					recvChan <- m
+		case c.proto:
+			switch m.Header.MsgType {
+			case wspf.MessageTypeError:
+				erro := new(ws.Error)
+				if err := msgpack.Unmarshal(m.Body, erro); err != nil &&
+					erro.MessageType != wspf.MessageTypePortForwardStop {
+					c.err = errors.New(fmt.Sprintf(
+						"Unable to start the port-forwarding: %s",
+						string(m.Body),
+					))
+					c.running = false
+					c.Stop()
 				}
+			case wspf.MessageTypePortForwardAck:
+				if c.proto == ws.ProtoTypePortForwardV2 {
+					c.err = fmt.Errorf("invalid message type %s", m.Header.MsgType)
+					c.running = false
+					c.Stop()
+					break
+				}
+				fallthrough
+			case wspf.MessageTypePortForward,
+				wspf.MessageTypePortForwardStop,
+				wspf.MessageTypePortForwardNew:
+				connectionID, _ := m.Header.Properties[wspf.PropertyConnectionID].(string)
+				if connectionID != "" {
+					if recvChan, ok := c.recvChans[connectionID]; ok {
+						recvChan <- m
+					}
+				}
+
+			default:
+				c.err = fmt.Errorf("invalid message type %s", m.Header.MsgType)
+				log.Err(c.err.Error())
+				c.running = false
+				c.Stop()
 			}
+		default:
+			c.err = fmt.Errorf("invalid protocol ID %d", m.Header.Proto)
+			log.Err(c.err.Error())
+			c.running = false
+			c.Stop()
+
 		}
 	}
 }

--- a/cmd/portforward_tcp.go
+++ b/cmd/portforward_tcp.go
@@ -105,6 +105,70 @@ func (p *TCPPortForwarder) Run(
 	}
 }
 
+// go routine to handle received messages
+func (p *TCPPortForwarder) handleDeviceMessages(
+	ctx context.Context,
+	msgChan chan<- *ws.ProtoMsg,
+	dataChan chan<- []byte,
+	recvChan <-chan *ws.ProtoMsg,
+	errChan chan<- error,
+	conn net.Conn,
+	sessionID, connectionID string,
+) {
+	started := false
+	for {
+		select {
+		case m := <-recvChan:
+			switch m.Header.MsgType {
+			case wspf.MessageTypePortForwardNew:
+				if started {
+					log.Err("duplicate new response received, discarding")
+					continue
+				}
+				// go routine to handle the network connection
+				go p.handleRequestConnection(dataChan, errChan, conn)
+				started = true
+
+			case wspf.MessageTypePortForwardStop,
+				wspf.MessageTypePortForward:
+				_, err := conn.Write(m.Body)
+				if err != nil {
+					if errors.Unwrap(err) != net.ErrClosed {
+						fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
+					}
+				} else if p.proto == ws.ProtoTypePortForward {
+					// send the ack
+					m := &ws.ProtoMsg{
+						Header: ws.ProtoHdr{
+							Proto:     ws.ProtoTypePortForward,
+							MsgType:   wspf.MessageTypePortForwardAck,
+							SessionID: sessionID,
+							Properties: map[string]interface{}{
+								wspf.PropertyConnectionID: connectionID,
+							},
+						},
+					}
+					msgChan <- m
+				}
+
+			case wspf.MessageTypePortForwardAck:
+				if p.proto == ws.ProtoTypePortForward {
+					if m, ok := p.mutexAck[connectionID]; ok {
+						m.Unlock()
+					}
+					break
+				}
+				fallthrough
+			default:
+				fmt.Fprintf(os.Stderr, "error: unrecognized message type %s\n",
+					m.Header.MsgType)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (p *TCPPortForwarder) handleRequest(
 	ctx context.Context,
 	conn net.Conn,
@@ -165,60 +229,11 @@ func (p *TCPPortForwarder) handleRequest(
 		}
 	}()
 
-	// go routine to handle received messages
-	go func(connectionID string) {
-		started := false
-		for {
-			select {
-			case m := <-recvChan:
-				switch m.Header.MsgType {
-				case wspf.MessageTypePortForwardNew:
-					if started {
-						log.Err("duplicate new response received, discarding")
-						continue
-					}
-					// go routine to handle the network connection
-					go p.handleRequestConnection(dataChan, errChan, conn)
-					started = true
-
-				case wspf.MessageTypePortForwardStop,
-					wspf.MessageTypePortForward:
-					_, err := conn.Write(m.Body)
-					if err != nil {
-						if errors.Unwrap(err) != net.ErrClosed {
-							fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
-						}
-					} else if p.proto == ws.ProtoTypePortForward {
-						// send the ack
-						m := &ws.ProtoMsg{
-							Header: ws.ProtoHdr{
-								Proto:     ws.ProtoTypePortForward,
-								MsgType:   wspf.MessageTypePortForwardAck,
-								SessionID: sessionID,
-								Properties: map[string]interface{}{
-									wspf.PropertyConnectionID: connectionID,
-								},
-							},
-						}
-						msgChan <- m
-					}
-
-				case wspf.MessageTypePortForwardAck:
-					if p.proto == ws.ProtoTypePortForward {
-						if m, ok := p.mutexAck[connectionID]; ok {
-							m.Unlock()
-						}
-						break
-					}
-					fallthrough
-				default:
-					fmt.Fprintf(os.Stderr, "error: unrecognized message type %s\n", m.Header.MsgType)
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}(connectionID)
+	go p.handleDeviceMessages(
+		ctx, msgChan, dataChan,
+		recvChan, errChan, conn,
+		sessionID, connectionID,
+	)
 
 	// go routine to handle sent messages
 	for {
@@ -253,8 +268,8 @@ func (p *TCPPortForwarder) handleRequest(
 }
 
 func (p *TCPPortForwarder) handleRequestConnection(
-	dataChan chan []byte,
-	errChan chan error,
+	dataChan chan<- []byte,
+	errChan chan<- error,
 	conn net.Conn,
 ) {
 	data := make([]byte, readBuffLength)

--- a/cmd/portforward_tcp.go
+++ b/cmd/portforward_tcp.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/mendersoftware/mender-cli/log"
+
 	"github.com/google/uuid"
 	"github.com/mendersoftware/go-lib-micro/ws"
 	"github.com/mendersoftware/go-lib-micro/ws/portforward"
@@ -38,6 +40,7 @@ type TCPPortForwarder struct {
 	remoteHost string
 	remotePort uint16
 	mutexAck   map[string]*sync.Mutex
+	proto      ws.ProtoType
 }
 
 func NewTCPPortForwarder(
@@ -45,6 +48,7 @@ func NewTCPPortForwarder(
 	localPort uint16,
 	remoteHost string,
 	remotePort uint16,
+	proto ws.ProtoType,
 ) (*TCPPortForwarder, error) {
 	fmt.Printf("Forwarding from %s:%d -> %s:%d\n", bindingHost, localPort, remoteHost, remotePort)
 	listen, err := net.Listen(protocolTCP, bindingHost+":"+strconv.Itoa(int(localPort)))
@@ -56,6 +60,7 @@ func NewTCPPortForwarder(
 		remoteHost: remoteHost,
 		remotePort: remotePort,
 		mutexAck:   map[string]*sync.Mutex{},
+		proto:      proto,
 	}, nil
 }
 
@@ -131,7 +136,7 @@ func (p *TCPPortForwarder) handleRequest(
 	}
 	m := &ws.ProtoMsg{
 		Header: ws.ProtoHdr{
-			Proto:     ws.ProtoTypePortForward,
+			Proto:     p.proto,
 			MsgType:   wspf.MessageTypePortForwardNew,
 			SessionID: sessionID,
 			Properties: map[string]interface{}{
@@ -148,7 +153,7 @@ func (p *TCPPortForwarder) handleRequest(
 		if sendStopMessage {
 			m := &ws.ProtoMsg{
 				Header: ws.ProtoHdr{
-					Proto:     ws.ProtoTypePortForward,
+					Proto:     p.proto,
 					MsgType:   wspf.MessageTypePortForwardStop,
 					SessionID: sessionID,
 					Properties: map[string]interface{}{
@@ -160,26 +165,30 @@ func (p *TCPPortForwarder) handleRequest(
 		}
 	}()
 
-	// go routine to handle the network connection
-	go p.handleRequestConnection(dataChan, errChan, conn)
-
 	// go routine to handle received messages
 	go func(connectionID string) {
+		started := false
 		for {
 			select {
 			case m := <-recvChan:
-				if m.Header.Proto == ws.ProtoTypePortForward &&
-					m.Header.MsgType == wspf.MessageTypePortForwardStop {
-					sendStopMessage = false
-					return
-				} else if m.Header.Proto == ws.ProtoTypePortForward &&
-					m.Header.MsgType == wspf.MessageTypePortForward {
+				switch m.Header.MsgType {
+				case wspf.MessageTypePortForwardNew:
+					if started {
+						log.Err("duplicate new response received, discarding")
+						continue
+					}
+					// go routine to handle the network connection
+					go p.handleRequestConnection(dataChan, errChan, conn)
+					started = true
+
+				case wspf.MessageTypePortForwardStop,
+					wspf.MessageTypePortForward:
 					_, err := conn.Write(m.Body)
 					if err != nil {
 						if errors.Unwrap(err) != net.ErrClosed {
 							fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
 						}
-					} else {
+					} else if p.proto == ws.ProtoTypePortForward {
 						// send the ack
 						m := &ws.ProtoMsg{
 							Header: ws.ProtoHdr{
@@ -193,11 +202,17 @@ func (p *TCPPortForwarder) handleRequest(
 						}
 						msgChan <- m
 					}
-				} else if m.Header.Proto == ws.ProtoTypePortForward &&
-					m.Header.MsgType == wspf.MessageTypePortForwardAck {
-					if m, ok := p.mutexAck[connectionID]; ok {
-						m.Unlock()
+
+				case wspf.MessageTypePortForwardAck:
+					if p.proto == ws.ProtoTypePortForward {
+						if m, ok := p.mutexAck[connectionID]; ok {
+							m.Unlock()
+						}
+						break
 					}
+					fallthrough
+				default:
+					fmt.Fprintf(os.Stderr, "error: unrecognized message type %s\n", m.Header.MsgType)
 				}
 			case <-ctx.Done():
 				return
@@ -214,12 +229,14 @@ func (p *TCPPortForwarder) handleRequest(
 			}
 			return
 		case data := <-dataChan:
-			// lock the ack mutex, we don't allow more than one in-flight message
-			p.mutexAck[connectionID].Lock()
+			if p.proto == ws.ProtoTypePortForward {
+				// lock the ack mutex, we don't allow more than one in-flight message
+				p.mutexAck[connectionID].Lock()
+			}
 
 			m := &ws.ProtoMsg{
 				Header: ws.ProtoHdr{
-					Proto:     ws.ProtoTypePortForward,
+					Proto:     p.proto,
 					MsgType:   wspf.MessageTypePortForward,
 					SessionID: sessionID,
 					Properties: map[string]interface{}{

--- a/cmd/portforward_udp.go
+++ b/cmd/portforward_udp.go
@@ -38,6 +38,7 @@ type UDPPortForwarder struct {
 	remotePort    uint16
 	sourceAddr    *net.UDPAddr
 	waitGroupAcks *sync.WaitGroup
+	proto         ws.ProtoType
 }
 
 func NewUDPPortForwarder(
@@ -45,6 +46,7 @@ func NewUDPPortForwarder(
 	localPort uint16,
 	remoteHost string,
 	remotePort uint16,
+	proto ws.ProtoType,
 ) (*UDPPortForwarder, error) {
 	fmt.Printf(
 		"Forwarding from udp/%s:%d -> udp/%s:%d\n",
@@ -62,6 +64,7 @@ func NewUDPPortForwarder(
 		return nil, err
 	}
 	return &UDPPortForwarder{
+		proto:         proto,
 		conn:          conn,
 		remoteHost:    remoteHost,
 		remotePort:    remotePort,
@@ -96,7 +99,7 @@ func (p *UDPPortForwarder) Run(
 	}
 	m := &ws.ProtoMsg{
 		Header: ws.ProtoHdr{
-			Proto:     ws.ProtoTypePortForward,
+			Proto:     p.proto,
 			MsgType:   wspf.MessageTypePortForwardNew,
 			SessionID: sessionID,
 			Properties: map[string]interface{}{
@@ -112,7 +115,7 @@ func (p *UDPPortForwarder) Run(
 		if sendStopMessage {
 			m := &ws.ProtoMsg{
 				Header: ws.ProtoHdr{
-					Proto:     ws.ProtoTypePortForward,
+					Proto:     p.proto,
 					MsgType:   wspf.MessageTypePortForwardStop,
 					SessionID: sessionID,
 					Properties: map[string]interface{}{
@@ -135,20 +138,20 @@ func (p *UDPPortForwarder) Run(
 		for {
 			select {
 			case m := <-recvChan:
-				if m.Header.Proto == ws.ProtoTypePortForward &&
+				if m.Header.Proto == p.proto &&
 					m.Header.MsgType == wspf.MessageTypePortForwardStop {
 					sendStopMessage = false
 					return
-				} else if m.Header.Proto == ws.ProtoTypePortForward &&
+				} else if m.Header.Proto == p.proto &&
 					m.Header.MsgType == wspf.MessageTypePortForward {
 					_, err := p.conn.WriteToUDP(m.Body, p.sourceAddr)
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
-					} else {
+					} else if p.proto == ws.ProtoTypePortForward {
 						// send the ack
 						m := &ws.ProtoMsg{
 							Header: ws.ProtoHdr{
-								Proto:     ws.ProtoTypePortForward,
+								Proto:     p.proto,
 								MsgType:   wspf.MessageTypePortForwardAck,
 								SessionID: sessionID,
 								Properties: map[string]interface{}{
@@ -177,15 +180,17 @@ func (p *UDPPortForwarder) Run(
 			}
 			return
 		case data := <-dataChan:
-			// wait to receive all the previous acks
-			p.waitGroupAcks.Wait()
+			if p.proto == ws.ProtoTypePortForward {
+				// wait to receive all the previous acks
+				p.waitGroupAcks.Wait()
 
-			// add an expected ack to the wait group
-			p.waitGroupAcks.Add(1)
+				// add an expected ack to the wait group
+				p.waitGroupAcks.Add(1)
+			}
 
 			m := &ws.ProtoMsg{
 				Header: ws.ProtoHdr{
-					Proto:     ws.ProtoTypePortForward,
+					Proto:     p.proto,
 					MsgType:   wspf.MessageTypePortForward,
 					SessionID: sessionID,
 					Properties: map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
-	github.com/mendersoftware/go-lib-micro v0.0.0-20221025103319-e1f941fb3145
+	github.com/mendersoftware/go-lib-micro v0.0.0-20260507072508-a0998f726f15
 	github.com/mendersoftware/mender-artifact v0.0.0-20250529094801-7264a90f1074
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
@@ -26,7 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/cheggaaa/pb/v3 v3.1.7/go.mod h1:/Ji89zfVPeC/u5j8ukD0MBPHt2bzTYp74lQ7K
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -32,6 +33,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
+github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -49,6 +52,10 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mendersoftware/go-lib-micro v0.0.0-20221025103319-e1f941fb3145 h1:ALhDv8wnoQJ4sgUm1mTcPuJd7uj589rg8mqX0SMEwTA=
 github.com/mendersoftware/go-lib-micro v0.0.0-20221025103319-e1f941fb3145/go.mod h1:E/DE4gIsSGq6iybd4IBq+4O/CkAwL/5xeU6zwlgWmW8=
+github.com/mendersoftware/go-lib-micro v0.0.0-20250620123909-c9fc306420c6 h1:QzRVsEJBKcDVPgAqxnr+zDfLbGXaKg2VLfcSU/ZgoTs=
+github.com/mendersoftware/go-lib-micro v0.0.0-20250620123909-c9fc306420c6/go.mod h1:CzlSoiOQvmyxmGnSmT7uaIYTT1SQXYD0jjX+nl/X6Ms=
+github.com/mendersoftware/go-lib-micro v0.0.0-20260507072508-a0998f726f15 h1:flR5o632Ub13HeiOeQ4SlHmnW60VQFAmThj9T14vYq0=
+github.com/mendersoftware/go-lib-micro v0.0.0-20260507072508-a0998f726f15/go.mod h1:CzlSoiOQvmyxmGnSmT7uaIYTT1SQXYD0jjX+nl/X6Ms=
 github.com/mendersoftware/mender-artifact v0.0.0-20250529094801-7264a90f1074 h1:uWBcuef1n5O4wACH7Vcpl4YkuQL65g4lHvr6AXxo6ps=
 github.com/mendersoftware/mender-artifact v0.0.0-20250529094801-7264a90f1074/go.mod h1:TTLcvt8oFyZRWDwrqhrD7URuivEgQAkB3gggDDLMs0k=
 github.com/mendersoftware/openssl v1.1.1-0.20221101135106-cb94d0a179f8 h1:LO1M218stEQBF3bFaTyKQeyhj7xCZTzcZEvEmG++h7g=
@@ -63,6 +70,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -111,6 +119,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
The new protocol is identical to v1 except v2 does not stop and wait for message acknowledgement. This immensely speeds up the throughput especially for higher latency.
Requires mender-server > 4.1 and mender-connect > 3.0. `mender-cli` will automatically fall back to v1 if the device does not report that it supports port-forwarding v2.

Ticket: MEN-5902