### PR TITLE
Added support for PAT credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 ---
+## Unreleased
+
+
+### Features
+
+
+- New `token` command group for managing the locally stored authentication
+  token without needing to know the platform-specific storage location:
+  `token set` (persist a Personal Access Token from a masked prompt or stdin,
+  with a server-side validation warning and JWT expiry hint on success),
+  `token show` (by default renders the decoded JWT header and payload as a
+  human-readable table with friendly claim labels and RFC3339 timestamps for
+  the standard date claims; `--json` emits the decoded header and payload as
+  JSON; `--raw` dumps the token verbatim), `token path` (print the default
+  storage path), and `token clear` (delete the stored token; requires `--yes`
+  in non-interactive contexts).
+
+
+---
 ## 2.0.0 - 2025-11-11
 
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,53 @@ Example configuration file:
 
 !!! Note: It is possible to override all configuration file parameters on the command line.
 
+## Using a Personal Access Token (PAT)
+
+Instead of running `mender-cli login` with a username and password, you can
+persist a Personal Access Token (PAT) — generated in the Mender UI under your
+user account — so every subsequent command authenticates with it. The token is
+saved to a platform-specific location; you never need to know exactly where.
+
+Set the token (interactive, masked prompt):
+
+```console
+mender-cli token set
+```
+
+Or pipe it in from a secret manager (no shell-history leak):
+
+```console
+op read "op://Personal/Mender PAT/credential" | mender-cli token set
+```
+
+Inspect the stored token. By default the JWT header and payload are rendered
+as a human-readable table with friendly claim labels and RFC3339 timestamps
+for the standard date claims (`exp`, `iat`, `nbf`, `auth_time`); the
+signature segment is intentionally omitted:
+
+```console
+mender-cli token show
+```
+
+Use `--json` to emit the decoded header and payload as JSON, or `--raw` to
+print the token verbatim (useful for piping to clipboard tools or
+`Authorization: Bearer` headers):
+
+```console
+mender-cli token show --json
+mender-cli token show --raw
+```
+
+Print the storage path, or remove the stored token:
+
+```console
+mender-cli token path
+mender-cli token clear
+```
+
+After `token set`, subsequent commands (e.g. `mender-cli artifacts list`) use
+the saved token automatically — no extra flags required.
+
 ## Autocompletion
 
 Autocompletion can be enabled for the `mender-cli` tool through one of two ways.

--- a/client/useradm/client.go
+++ b/client/useradm/client.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	loginUrl = "/api/management/v1/useradm/auth/login"
+	meUrl    = "/api/management/v1/useradm/users/me"
 	timeout  = 10 * time.Second
 )
 
@@ -91,4 +92,49 @@ func (c *Client) Login(user, pass string, token string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+// VerifyError is returned by Verify when the server explicitly rejects the
+// token (HTTP 401/403), as opposed to a transport-level failure.
+type VerifyError struct {
+	StatusCode int
+}
+
+func (e *VerifyError) Error() string {
+	return fmt.Sprintf("token rejected by server (status %d)", e.StatusCode)
+}
+
+// Verify checks that the given token is accepted by the configured server by
+// calling GET /useradm/users/me. It returns nil on HTTP 200, a *VerifyError on
+// 401/403, and a generic error for any other transport or status failure.
+func (c *Client) Verify(token string) error {
+	req, err := http.NewRequest(http.MethodGet, client.JoinURL(c.url, meUrl), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create verify request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	reqDump, _ := httputil.DumpRequest(req, false)
+	log.Verbf("sending request: \n%v", string(reqDump))
+
+	rsp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "GET /useradm/users/me request failed")
+	}
+	defer rsp.Body.Close()
+
+	rspDump, _ := httputil.DumpResponse(rsp, true)
+	log.Verbf("response: \n%v\n", string(rspDump))
+
+	switch rsp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return &VerifyError{StatusCode: rsp.StatusCode}
+	default:
+		return fmt.Errorf("verify failed with status %d", rsp.StatusCode)
+	}
 }

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// decodeJWT parses a compact-serialized JWT and returns its decoded header and
+// payload as generic maps. The signature segment is intentionally not returned
+// or validated — mender-cli is an API client, not the auth server.
+func decodeJWT(token string) (header, payload map[string]any, err error) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) != 3 {
+		return nil, nil, fmt.Errorf(
+			"not a JWT: expected 3 dot-separated segments, got %d", len(parts))
+	}
+
+	header, err = decodeJWTSegment(parts[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid JWT header: %w", err)
+	}
+	payload, err = decodeJWTSegment(parts[1])
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid JWT payload: %w", err)
+	}
+	return header, payload, nil
+}
+
+func decodeJWTSegment(seg string) (map[string]any, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		// Some encoders include padding; tolerate that.
+		raw, err = base64.URLEncoding.DecodeString(seg)
+		if err != nil {
+			return nil, fmt.Errorf("base64 decode failed: %w", err)
+		}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("json decode failed: %w", err)
+	}
+	return out, nil
+}
+
+// jwtExpiry returns the value of the "exp" claim as a time, plus true if a
+// numeric exp claim was present.
+func jwtExpiry(payload map[string]any) (time.Time, bool) {
+	v, ok := payload["exp"]
+	if !ok {
+		return time.Time{}, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return time.Unix(int64(n), 0), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return time.Time{}, false
+		}
+		return time.Unix(i, 0), true
+	default:
+		return time.Time{}, false
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/howeyc/gopass"
@@ -158,18 +157,8 @@ func (c *LoginCmd) maybeGetPassword() error {
 }
 
 func (c *LoginCmd) saveToken(t []byte) error {
-	dir := filepath.Dir(c.tokenPath)
-	log.Verbf("creating directory: %v\n", dir)
-
-	err := os.MkdirAll(dir, os.ModeDir|0700)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create directory %s", dir)
-
-	}
-
-	err = os.WriteFile(c.tokenPath, t, 0600)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create file %s", c.tokenPath)
+	if err := writeAuthToken(c.tokenPath, t); err != nil {
+		return err
 	}
 
 	log.Verb("saved token to: " + c.tokenPath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,5 +138,6 @@ func init() {
 	rootCmd.AddCommand(terminalCmd)
 	rootCmd.AddCommand(portForwardCmd)
 	rootCmd.AddCommand(fileTransferCmd)
+	rootCmd.AddCommand(tokenCmd)
 	validateConfiguration()
 }

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import "github.com/spf13/cobra"
+
+// tokenCmd is the parent for token-management subcommands.
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage the locally stored authentication token",
+	Long: "Manage the locally stored authentication token (e.g. a Personal " +
+		"Access Token) without needing to know the on-disk storage location.",
+}
+
+func init() {
+	tokenCmd.AddCommand(tokenSetCmd)
+	tokenCmd.AddCommand(tokenShowCmd)
+	tokenCmd.AddCommand(tokenPathCmd)
+	tokenCmd.AddCommand(tokenClearCmd)
+}

--- a/cmd/token_clear.go
+++ b/cmd/token_clear.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mendersoftware/mender-cli/log"
+)
+
+const argTokenClearYes = "yes"
+
+var tokenClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Delete the locally stored authentication token.",
+	Long: "Delete the locally stored authentication token. By default an " +
+		"interactive confirmation is required; use --yes to skip it. In " +
+		"non-interactive contexts --yes is mandatory.",
+	Run: func(c *cobra.Command, args []string) {
+		yes, err := c.Flags().GetBool(argTokenClearYes)
+		CheckErr(err)
+		CheckErr(runTokenClear(c, yes))
+	},
+}
+
+func init() {
+	tokenClearCmd.Flags().BoolP(argTokenClearYes, "y", false,
+		"do not prompt for confirmation before deleting")
+}
+
+func runTokenClear(cmd *cobra.Command, yes bool) error {
+	path, err := resolveTokenPath(cmd)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			log.Info("no token stored")
+			return nil
+		}
+		return fmt.Errorf("failed to stat token file: %w", err)
+	}
+
+	if !yes {
+		if !isStdinTTY() {
+			return errors.New(
+				"refusing to delete token without --yes in non-interactive mode")
+		}
+		fmt.Fprintf(os.Stderr, "Delete stored token at %s? [y/N]: ", path)
+		reader := bufio.NewReader(os.Stdin)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read confirmation: %w", err)
+		}
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			log.Info("aborted; token not deleted")
+			return nil
+		}
+	}
+
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("failed to delete token: %w", err)
+	}
+	log.Info("token cleared")
+	return nil
+}

--- a/cmd/token_path.go
+++ b/cmd/token_path.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var tokenPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the default on-disk storage path for the authentication token.",
+	Long: "Print the absolute filesystem path where mender-cli stores the " +
+		"authentication token by default. This always reflects the default " +
+		"platform-specific location and ignores any --token override.",
+	Run: func(c *cobra.Command, args []string) {
+		path, err := getDefaultAuthTokenPath()
+		CheckErr(err)
+		fmt.Println(path)
+	},
+}

--- a/cmd/token_set.go
+++ b/cmd/token_set.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/howeyc/gopass"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/mendersoftware/mender-cli/client/useradm"
+	"github.com/mendersoftware/mender-cli/log"
+)
+
+var tokenSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Persist an authentication token (e.g. a Personal Access Token).",
+	Long: "Persist an authentication token in the local store used by all other " +
+		"mender-cli commands. The token is read from stdin when piped, or via a " +
+		"masked interactive prompt otherwise. After saving, the token is " +
+		"validated against the configured server; a failed validation only " +
+		"produces a warning — the token is always saved.",
+	Run: func(c *cobra.Command, args []string) {
+		cmd, err := NewSetTokenCmd(c, args)
+		CheckErr(err)
+		CheckErr(cmd.Run())
+	},
+}
+
+// SetTokenCmd implements `mender-cli token set`.
+type SetTokenCmd struct {
+	server     string
+	skipVerify bool
+	tokenPath  string
+	stdin      io.Reader
+	stdinIsTTY bool
+	prompt     func() ([]byte, error)
+	// verifier verifies the token against the configured server. Injectable
+	// for testing. When nil, a real useradm.Client is used.
+	verifier func(server string, skipVerify bool, token string) error
+}
+
+func NewSetTokenCmd(cmd *cobra.Command, _ []string) (*SetTokenCmd, error) {
+	server := viper.GetString(argRootServer)
+	if server == "" {
+		return nil, errors.New("no server configured")
+	}
+
+	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenPath, err := cmd.Flags().GetString(argRootToken)
+	if err != nil {
+		return nil, err
+	}
+	if tokenPath == "" {
+		tokenPath, err = getDefaultAuthTokenPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SetTokenCmd{
+		server:     server,
+		skipVerify: skipVerify,
+		tokenPath:  tokenPath,
+		stdin:      os.Stdin,
+		stdinIsTTY: isStdinTTY(),
+		prompt:     gopass.GetPasswdMasked,
+	}, nil
+}
+
+func (c *SetTokenCmd) Run() error {
+	token, err := c.readToken()
+	if err != nil {
+		return err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return errors.New("empty token; refusing to save")
+	}
+
+	if err := writeAuthToken(c.tokenPath, []byte(token)); err != nil {
+		return err
+	}
+	log.Verb("saved token to: " + c.tokenPath)
+	log.Info("token saved")
+
+	c.verify(token)
+	return nil
+}
+
+func (c *SetTokenCmd) readToken() (string, error) {
+	if !c.stdinIsTTY {
+		b, err := io.ReadAll(c.stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read token from stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	fmt.Fprint(os.Stderr, "Personal Access Token: ")
+	b, err := c.prompt()
+	if err != nil {
+		return "", fmt.Errorf("failed to read token: %w", err)
+	}
+	return string(b), nil
+}
+
+func (c *SetTokenCmd) verify(token string) {
+	verify := c.verifier
+	if verify == nil {
+		verify = func(server string, skipVerify bool, token string) error {
+			return useradm.NewClient(server, skipVerify).Verify(token)
+		}
+	}
+	if err := verify(c.server, c.skipVerify, token); err != nil {
+		var ve *useradm.VerifyError
+		if errors.As(err, &ve) {
+			log.Errf("warning: server rejected the token (%s); saved anyway", err)
+		} else {
+			log.Errf("warning: could not verify token against %s (%s); saved anyway",
+				c.server, err)
+		}
+		return
+	}
+	log.Infof("token verified against %s", c.server)
+
+	// On success, surface the expiry from the JWT exp claim if present.
+	_, payload, err := decodeJWT(token)
+	if err != nil {
+		// Opaque (non-JWT) PATs are valid; nothing to surface.
+		log.Verbf("token is not a JWT, skipping expiry parsing: %v", err)
+		return
+	}
+	exp, ok := jwtExpiry(payload)
+	if !ok {
+		return
+	}
+	now := time.Now()
+	if exp.Before(now) {
+		log.Errf("warning: token expired %s ago (at %s)",
+			humanDuration(now.Sub(exp)), exp.Format(time.RFC3339))
+		return
+	}
+	log.Infof("token expires in %s (at %s)",
+		humanDuration(exp.Sub(now)), exp.Format(time.RFC3339))
+}
+
+// isStdinTTY reports whether os.Stdin is connected to a character device
+// (terminal). Returns true if stat fails, treating the unknown case as
+// "interactive" to avoid silently consuming pipe data that isn't there.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return true
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// humanDuration formats d as a coarse human-readable string ("27 days",
+// "3 hours", "45 minutes"). Sub-minute durations round to "less than a minute".
+func humanDuration(d time.Duration) string {
+	if d < time.Minute {
+		return "less than a minute"
+	}
+	const day = 24 * time.Hour
+	switch {
+	case d >= day:
+		days := int(math.Round(d.Hours() / 24))
+		return pluralize(days, "day")
+	case d >= time.Hour:
+		hours := int(math.Round(d.Hours()))
+		return pluralize(hours, "hour")
+	default:
+		mins := int(math.Round(d.Minutes()))
+		return pluralize(mins, "minute")
+	}
+}
+
+func pluralize(n int, unit string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, unit)
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
+}

--- a/cmd/token_show.go
+++ b/cmd/token_show.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	argTokenShowRaw  = "raw"
+	argTokenShowJSON = "json"
+)
+
+// jwtDateClaims lists the standard JWT registered claim names that hold a
+// NumericDate (seconds since the Unix epoch). In the default decoded view,
+// each of these is rendered as an RFC3339 timestamp with a relative-time
+// hint.
+var jwtDateClaims = map[string]bool{
+	"exp":       true,
+	"iat":       true,
+	"nbf":       true,
+	"auth_time": true,
+}
+
+// jwtClaimLabels maps well-known JWT / OIDC / mender claim names to friendly
+// labels used by the default decoded view. Unknown keys are rendered with
+// their raw name.
+var jwtClaimLabels = map[string]string{
+	// RFC 7519 registered claims
+	"iss": "Issuer",
+	"sub": "Subject",
+	"aud": "Audience",
+	"exp": "Expiration",
+	"nbf": "Not Before",
+	"iat": "Issued At",
+	"jti": "JWT ID",
+	// Common OIDC / OAuth2 claims
+	"auth_time": "Auth Time",
+	"azp":       "Authorized Party",
+	"scp":       "Scope",
+	"scope":     "Scope",
+	"email":     "Email",
+	"name":      "Name",
+	// JOSE header
+	"alg": "Algorithm",
+	"typ": "Type",
+	"kid": "Key ID",
+	"cty": "Content Type",
+	// mender-specific
+	"mender.tenant": "Tenant",
+	"mender.plan":   "Plan",
+	"mender.trial":  "Trial",
+	"mender.user":   "User",
+	"mender.addons": "Add-ons",
+}
+
+var tokenShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the locally stored token (JWT header + payload, decoded).",
+	Long: "Print the locally stored authentication token. By default the JWT " +
+		"header and payload are rendered as a human-readable table with " +
+		"friendly claim labels and RFC3339 timestamps for the standard date " +
+		"claims (exp, iat, nbf, auth_time); the signature segment is " +
+		"intentionally omitted. Use --json to emit the decoded header and " +
+		"payload as JSON. Use --raw to print the token verbatim (useful for " +
+		"piping to clipboard tools or Authorization headers).",
+	Run: func(c *cobra.Command, args []string) {
+		raw, err := c.Flags().GetBool(argTokenShowRaw)
+		CheckErr(err)
+		asJSON, err := c.Flags().GetBool(argTokenShowJSON)
+		CheckErr(err)
+		if raw && asJSON {
+			CheckErr(fmt.Errorf("--raw and --json are mutually exclusive"))
+		}
+		CheckErr(runTokenShow(c, raw, asJSON, os.Stdout))
+	},
+}
+
+func init() {
+	tokenShowCmd.Flags().Bool(argTokenShowRaw, false,
+		"print the unparsed token verbatim instead of the decoded JWT")
+	tokenShowCmd.Flags().Bool(argTokenShowJSON, false,
+		"print the decoded JWT header and payload as JSON")
+}
+
+func runTokenShow(cmd *cobra.Command, raw, asJSON bool, out io.Writer) error {
+	path, err := resolveTokenPath(cmd)
+	if err != nil {
+		return err
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New(
+				"no token stored; run `mender-cli login` or " +
+					"`mender-cli token set` first")
+		}
+		return fmt.Errorf("failed to read token: %w", err)
+	}
+	token := strings.TrimSpace(string(contents))
+
+	if raw {
+		fmt.Fprintln(out, token)
+		return nil
+	}
+
+	header, payload, err := decodeJWT(token)
+	if err != nil {
+		return fmt.Errorf("stored token is not a JWT: %w "+
+			"(use --raw to print it verbatim)", err)
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(map[string]any{
+			"header":  header,
+			"payload": payload,
+		})
+	}
+
+	return renderDecodedJWT(out, header, payload)
+}
+
+// renderDecodedJWT prints the JWT header and payload as a friendly aligned
+// table: one section per part, friendly labels for known claim names, RFC3339
+// timestamps with a relative-time hint for standard date claims, compact JSON
+// for nested arrays / objects.
+func renderDecodedJWT(out io.Writer, header, payload map[string]any) error {
+	now := time.Now()
+	if _, err := fmt.Fprintln(out, "Header:"); err != nil {
+		return err
+	}
+	if err := writeClaimTable(out, header, now); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out, "\nPayload:"); err != nil {
+		return err
+	}
+	return writeClaimTable(out, payload, now)
+}
+
+func writeClaimTable(out io.Writer, claims map[string]any, now time.Time) error {
+	keys := make([]string, 0, len(claims))
+	for k := range claims {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return claimLabel(keys[i]) < claimLabel(keys[j])
+	})
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, k := range keys {
+		label := claimLabel(k)
+		value := formatClaimValue(k, claims[k], now)
+		if _, err := fmt.Fprintf(tw, "  %s:\t%s\n", label, value); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func claimLabel(key string) string {
+	if l, ok := jwtClaimLabels[key]; ok {
+		return l
+	}
+	return key
+}
+
+// formatClaimValue renders a single claim value. Known date claims are shown
+// as RFC3339 UTC with a relative-time hint. Strings / bools / numbers are
+// rendered verbatim. Arrays and objects fall back to compact JSON so they
+// stay on one line.
+func formatClaimValue(key string, v any, now time.Time) string {
+	if jwtDateClaims[key] {
+		if sec, ok := toUnixSeconds(v); ok {
+			return formatTimestamp(sec, now)
+		}
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		return fmt.Sprintf("%t", x)
+	case float64:
+		// JSON numbers come in as float64; print without a trailing .0 when
+		// the value is integral.
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+		return fmt.Sprintf("%g", x)
+	case json.Number:
+		return x.String()
+	case nil:
+		return "null"
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
+	}
+}
+
+func formatTimestamp(sec int64, now time.Time) string {
+	t := time.Unix(sec, 0).UTC()
+	diff := t.Sub(now)
+	rel := "in " + humanDuration(diff)
+	if diff < 0 {
+		rel = humanDuration(-diff) + " ago"
+	}
+	return fmt.Sprintf("%s (%s)", t.Format(time.RFC3339), rel)
+}
+
+func toUnixSeconds(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
+}
+
+// resolveTokenPath returns the token path that subcommands should read/write,
+// honoring the persistent --token override or falling back to the default
+// platform-specific location.
+func resolveTokenPath(cmd *cobra.Command) (string, error) {
+	tokenPath, err := cmd.Flags().GetString(argRootToken)
+	if err != nil {
+		return "", err
+	}
+	if tokenPath != "" {
+		return tokenPath, nil
+	}
+	return getDefaultAuthTokenPath()
+}

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeJWT(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	header := map[string]any{"alg": "HS256", "typ": "JWT"}
+	enc := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	return enc(header) + "." + enc(payload) + ".sig"
+}
+
+func TestDecodeJWT_RoundTrip(t *testing.T) {
+	tok := makeJWT(t, map[string]any{"sub": "alice", "exp": float64(123)})
+	h, p, err := decodeJWT(tok)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if h["alg"] != "HS256" {
+		t.Errorf("header alg = %v", h["alg"])
+	}
+	if p["sub"] != "alice" {
+		t.Errorf("payload sub = %v", p["sub"])
+	}
+}
+
+func TestDecodeJWT_Errors(t *testing.T) {
+	cases := map[string]string{
+		"single segment": "abc",
+		"two segments":   "abc.def",
+		"bad base64":     "!!!.def.sig",
+		"bad json":       base64.RawURLEncoding.EncodeToString([]byte("not-json")) + ".def.sig",
+	}
+	for name, tok := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := decodeJWT(tok); err == nil {
+				t.Errorf("expected error for %q", tok)
+			}
+		})
+	}
+}
+
+func TestJWTExpiry(t *testing.T) {
+	exp := time.Now().Add(7 * 24 * time.Hour).Unix()
+	_, p, err := decodeJWT(makeJWT(t, map[string]any{"exp": float64(exp)}))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := jwtExpiry(p)
+	if !ok {
+		t.Fatal("expected exp claim")
+	}
+	if got.Unix() != exp {
+		t.Errorf("exp = %d, want %d", got.Unix(), exp)
+	}
+
+	if _, ok := jwtExpiry(map[string]any{}); ok {
+		t.Error("expected no exp")
+	}
+	if _, ok := jwtExpiry(map[string]any{"exp": "not-a-number"}); ok {
+		t.Error("expected exp parse failure to return ok=false")
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "less than a minute"},
+		{time.Minute, "1 minute"},
+		{2 * time.Minute, "2 minutes"},
+		{time.Hour, "1 hour"},
+		{3 * time.Hour, "3 hours"},
+		{27 * 24 * time.Hour, "27 days"},
+	}
+	for _, tc := range cases {
+		if got := humanDuration(tc.d); got != tc.want {
+			t.Errorf("humanDuration(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// stripANSI is unused but kept available; the real value is the explicit
+// assertions below.
+
+func TestSetTokenCmd_Run_StdinPiped(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/authtoken"
+	c := &SetTokenCmd{
+		server:     "http://invalid.example",
+		tokenPath:  path,
+		stdin:      strings.NewReader("  abc.def.sig\n"),
+		stdinIsTTY: false,
+		prompt:     func() ([]byte, error) { t.Fatal("prompt should not be called"); return nil, nil },
+		verifier:   func(string, bool, string) error { return nil },
+	}
+	if err := c.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "abc.def.sig" {
+		t.Errorf("file contents = %q, want %q", string(got), "abc.def.sig")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+func TestSetTokenCmd_Run_RejectsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/authtoken"
+	c := &SetTokenCmd{
+		server:     "http://invalid.example",
+		tokenPath:  path,
+		stdin:      strings.NewReader("   \n"),
+		stdinIsTTY: false,
+	}
+	if err := c.Run(); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("file should not be created for empty input")
+	}
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/mendersoftware/mender-cli/log"
 )
 
 func CheckErr(e error) {
@@ -78,6 +80,20 @@ func getDefaultAuthTokenPath() (string, error) {
 	migrateAuthToken(oldtoken, token)
 
 	return token, nil
+}
+
+// writeAuthToken persists the given token bytes to path with 0600 permissions,
+// creating any missing parent directories with 0700.
+func writeAuthToken(path string, token []byte) error {
+	dir := filepath.Dir(path)
+	log.Verb("creating directory: " + dir)
+	if err := os.MkdirAll(dir, os.ModeDir|0700); err != nil {
+		return errors.Wrapf(err, "failed to create directory %s", dir)
+	}
+	if err := os.WriteFile(path, token, 0600); err != nil {
+		return errors.Wrapf(err, "failed to create file %s", path)
+	}
+	return nil
 }
 
 func getAuthToken(cmd *cobra.Command) (string, error) {


### PR DESCRIPTION
# Add `mender-cli token` command group for managing PATs

## Summary

Adds a new `token` command group that lets users persist, inspect, and remove
the locally-stored authentication token (typically a Personal Access Token
generated in the Mender UI) without needing to know the platform-specific
storage location.

Today, switching from `mender-cli login` to a long-lived PAT requires either
passing `--token-value` on every invocation or knowing exactly where on disk
the auth token cache lives (e.g. `$XDG_CACHE_HOME/mender/authtoken` /
`~/.cache/mender/authtoken`) and writing the file by hand with the right
permissions. This change removes that friction.

## Motivation

PATs are the recommended authentication method for CI pipelines, scripted
automation, and headless workstations where running an interactive
`mender-cli login` (and storing a username/password in `.mender-clirc`) is
undesirable. Providing first-class CLI verbs for the token cache:

- removes the need to document or remember the on-disk path,
- makes secret-manager integration trivial (`op read … | mender-cli token set`),
- gives users a safe way to inspect what they've stored, including expiry,
- and gives users a single deliberate way to revoke local access
  (`mender-cli token clear`).

## What's new

A new `token` subcommand with four verbs:

| Command              | Behaviour                                                                                       |
| -------------------- | ----------------------------------------------------------------------------------------------- |
| `token set`          | Read a token from a masked TTY prompt, or from stdin when piped. Writes `0600` to the cache.    |
| `token show`         | Render the decoded JWT header + payload as a human-readable table (default).                    |
| `token show --json`  | Same content as the default view, but emitted as indented JSON.                                 |
| `token show --raw`   | Print the token verbatim (useful for `Authorization: Bearer …` headers and clipboard tools).    |
| `token path`         | Print the platform-specific default storage path.                                                |
| `token clear`        | Delete the stored token. Refuses to run non-interactively without `--yes` / `-y`.                |

### `token set` highlights

- Honours the existing global `--token` flag for overriding the path.
- Reads from stdin when stdin is not a TTY, so it composes cleanly with secret
  managers and CI secrets:
  ```console
  op read "op://Personal/Mender PAT/credential" | mender-cli token set
  ```
- Performs an optional best-effort server-side validation against
  `GET /api/management/v1/useradm/users/me`. A 401/403 prints a soft warning
  but the token is still saved (the user may be offline, on a VPN with split
  DNS, etc.). Other errors are also reported as warnings.
- On a successful save it parses the JWT locally and prints a friendly
  expiry hint, e.g. `token expires in 6 days (at 2026-06-09T14:13:26Z)`.

### `token show` highlights

The default view groups the decoded JWT into a friendly table with
human-readable claim labels and RFC3339 timestamps:

```console
$ mender-cli token show
Header:
  Algorithm:  RS256
  Key ID:     0
  Type:       JWT

Payload:
  Issued At:    2026-04-27T11:42:08Z (37 days ago)
  Issuer:       eu.hosted.mender.io
  JWT ID:       47545c20-737c-408b-88f8-551a62b24936
  Not Before:   2026-04-27T11:42:08Z (37 days ago)
  Plan:         os
  Scope:        mender.*
  Subject:      be64faf2-d77f-4930-9e0a-52b9af50698d
  Tenant:       66859d4850f45af02036eb2f
  Trial:        false
  User:         true
```

The signature segment is intentionally **not** decoded or displayed — the CLI
is a relying party, not the issuer.

## Implementation notes

- **Pure stdlib JWT parsing.** Token decoding is done with
  `encoding/base64.RawURLEncoding` + `encoding/json`. Signature verification
  is deliberately out of scope — the server is the authority on validity, and
  `token set` exercises that via the existing `useradm` client.
- **Reused helpers, no duplicated logic.**
  - `getDefaultAuthTokenPath` (existing) is now shared between `login` and
    every `token` subcommand.
  - A new `writeAuthToken` helper centralises the `0700 dir` + `0600 file`
    write that previously lived inside `cmd/login.go`. `login.saveToken` now
    delegates to it.
  - A new `(*useradm.Client).Verify(token)` plus a typed `VerifyError`
    distinguishes auth failures (401/403) from transport/other failures so
    `token set` can word its warning appropriately.
- **Testability.** `SetTokenCmd` accepts injected `stdin`, `prompt`, and
  `verifier` collaborators so unit tests don't touch the network or a real
  terminal. The verify call defaults to `useradm.Client.Verify` in
  production.
- **Cross-platform storage.** Storage path resolution is unchanged
  (`getDefaultAuthTokenPath` honours `$XDG_CACHE_HOME` and falls back to
  `~/.cache/mender/authtoken`). No keychain integration is introduced.

## Files

```
 CHANGELOG.md             |  19 ++
 README.md                |  47 +++
 client/useradm/client.go |  46 +++
 cmd/jwt.go               |  79 +++++   (new)
 cmd/login.go             |  15 +-      (saveToken now delegates)
 cmd/root.go              |   1 +       (register tokenCmd)
 cmd/token.go             |  31 ++      (new — parent command)
 cmd/token_clear.go       |  84 +++++   (new)
 cmd/token_path.go        |  33 ++      (new)
 cmd/token_set.go         | 205 +++++++ (new)
 cmd/token_show.go        | 262 ++++++  (new)
 cmd/token_test.go        | 157 +++++   (new)
 cmd/util.go              |  13 +       (writeAuthToken helper)
 13 files changed, 979 insertions(+), 13 deletions(-)
```

## Backwards compatibility

- No existing flags, commands, or output formats change.
- `mender-cli login` continues to work unchanged; its underlying write path
  is now shared with `token set` but produces a bit-identical file.
- The persistent global `--token` flag is honoured by every new subcommand
  (`token set` writes to the override path; `token show` reads from it;
  `token path` deliberately ignores it and reports the *default* location).

## Testing

- New unit tests in `cmd/token_test.go` cover:
  - `decodeJWT` happy path + malformed/short/non-base64/non-JSON inputs,
  - `jwtExpiry` over numeric and non-numeric claim values,
  - `humanDuration` formatting,
  - `SetTokenCmd.Run` with piped stdin: verifies `0600` mode and trimmed
    contents written to disk,
  - `SetTokenCmd.Run` rejects empty input.
- Full test suite green:
  ```console
  CGO_ENABLED=0 go test -tags nopkcs11 ./...
  ```
- Manual smoke test against `eu.hosted.mender.io`:
  - `printf '%s' "$PAT" | mender-cli token set` → file written `0600`,
    expected expiry hint printed, soft warning shown when the server
    rejects the validation call.
  - `mender-cli token show`, `--json`, `--raw` all produce the documented
    output.
  - `mender-cli token path` prints the cache path.
  - `mender-cli token clear --yes` removes the file.

## Security considerations

- Tokens are never echoed to the terminal during `token set` (masked prompt
  via `gopass`).
- The stored file is created with `0600` under a `0700` parent, matching the
  existing `login` behaviour.
- `token show` omits the JWT signature segment by design.
- No new transports, no new on-disk locations, no new dependencies.

## Documentation

- `README.md`: new "Using a Personal Access Token (PAT)" section between
  "Configuration file" and "Autocompletion".
- `CHANGELOG.md`: entry under `## Unreleased` → `### Features`.

## Out of scope (not in this PR)

- OS keychain / secret-service integration.
- Environment-variable binding for `--token-value` (still requires the flag
  or the new `token set`).
- Automatic token refresh.

These can land as follow-ups if there's appetite for them.
