### PR TITLE
ci: run acceptance tests on prebuilt image with baked uamqp

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,18 +201,15 @@ test:integration:
     GIT_SUBMODULE_STRATEGY: recursive
     GIT_SUBMODULE_DEPTH: 1
     CLIENT_VERSION: "latest"
-  image: docker:${DOCKER_VERSION}
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/mender-cli-acceptance-testing:master
   needs:
     - compile
   before_script:
     - mkdir -p $HOME/.docker
     - echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
     - echo "127.0.0.1 docker.mender.io" >> /etc/hosts
-    # we need to upgrade installed packages so they don't diverge from freshly installed ones (e.g. expat vs. pyexpat)
-    - apk upgrade --no-cache
-    - apk add --no-cache bash cmake curl dpkg e2fsprogs-extra g++ gcompat git iptables jq libffi-dev make openssh-client py3-pip python3-dev zstd screen openssl-dev openssl-libs-static
-    # Workaround for "Failed building wheel for uamqp" error
-    - CFLAGS="-Wno-error=incompatible-pointer-types" CMAKE_POLICY_VERSION_MINIMUM=3.5 pip install uamqp --break-system-packages
+    # System packages and the source-compiled uamqp are baked into the image (QA-1637);
+    # only the repo-local requirements are installed at runtime.
     - pip install --ignore-installed -r tests/mender_server/backend/tests/requirements-integration.txt --break-system-packages
     - pip install -r tests/integration/requirements.txt --break-system-packages
     # Gitlab CI tends to set these DOCKER_ variables internally.


### PR DESCRIPTION
## What
Points the `test:integration` job at the prebuilt `mender-cli-acceptance-testing` image and drops
the runtime `apk upgrade`/`apk add` (~20 pkgs) and the source-compiled `pip install uamqp`. The two
repo-local `pip install -r requirements*.txt` lines stay (they reference in-repo files that change
per branch — the correct place for `cache:`, not image baking).

## Why
QA-1637 pilot consumer: removes the flakiest install in the repo (the `uamqp` C compile) from every
acceptance run.

## Depends on (merge order)
1. mender-test-containers PR #723 — `mender-cli-acceptance-testing` image built/published (manual job)

CI here will be red until that image exists; expected, not a defect.

## Expected result once green
The job log contains **no** `apk add` / `pip install uamqp` lines.

Ticket: QA-1637