### PR TITLE
feat(login): Persist non-default --server to the config file

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -55,12 +55,13 @@ func init() {
 }
 
 type LoginCmd struct {
-	server     string
-	skipVerify bool
-	username   string
-	password   string
-	token      string
-	tokenPath  string
+	server        string
+	serverChanged bool
+	skipVerify    bool
+	username      string
+	password      string
+	token         string
+	tokenPath     string
 }
 
 func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
@@ -68,6 +69,7 @@ func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
 	if server == "" {
 		return nil, errors.New("No server, this should not happen")
 	}
+	serverChanged := cmd.Flags().Changed(argRootServer)
 
 	skipVerify, err := cmd.Flags().GetBool(argRootSkipVerify)
 	if err != nil {
@@ -95,12 +97,13 @@ func NewLoginCmd(cmd *cobra.Command, args []string) (*LoginCmd, error) {
 	}
 
 	return &LoginCmd{
-		server:     server,
-		username:   username,
-		password:   password,
-		token:      tfaToken,
-		tokenPath:  token,
-		skipVerify: skipVerify,
+		server:        server,
+		serverChanged: serverChanged,
+		username:      username,
+		password:      password,
+		token:         tfaToken,
+		tokenPath:     token,
+		skipVerify:    skipVerify,
 	}, nil
 }
 
@@ -124,6 +127,8 @@ func (c *LoginCmd) Run() error {
 	if err != nil {
 		return err
 	}
+
+	c.maybePersistServer()
 
 	return nil
 }

--- a/cmd/login_config.go
+++ b/cmd/login_config.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+
+	"github.com/mendersoftware/mender-cli/log"
+)
+
+// persistServerToConfig ensures the JSON config file at path has a "server"
+// key set to server. It creates the file (and any missing parent directories)
+// if it does not exist. If the file already contains a "server" key, it is
+// left untouched and false is returned. Otherwise the key is written and true
+// is returned.
+func persistServerToConfig(path string, server string) (bool, error) {
+	var content map[string]interface{}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, errors.Wrapf(err, "failed to read config file %s", path)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return false, errors.Wrapf(err, "failed to create directory for %s", path)
+		}
+		content = map[string]interface{}{}
+	} else {
+		if err := json.Unmarshal(data, &content); err != nil {
+			return false, errors.Wrapf(err, "failed to parse config file %s as JSON", path)
+		}
+		if _, exists := content[argRootServer]; exists {
+			return false, nil
+		}
+	}
+
+	content[argRootServer] = server
+
+	out, err := json.MarshalIndent(content, "", "  ")
+	if err != nil {
+		return false, errors.Wrap(err, "failed to encode config file content")
+	}
+	out = append(out, '\n')
+
+	if err := os.WriteFile(path, out, 0600); err != nil {
+		return false, errors.Wrapf(err, "failed to write config file %s", path)
+	}
+
+	return true, nil
+}
+
+// resolveConfigFilePath returns the config file path to persist the server
+// to: the file viper actually loaded, if any, or otherwise
+// $HOME/.mender-clirc.
+func resolveConfigFilePath(viperConfigFileUsed string, userHomeDir func() (string, error)) string {
+	if viperConfigFileUsed != "" {
+		return viperConfigFileUsed
+	}
+
+	home, err := userHomeDir()
+	if err != nil {
+		return ".mender-clirc"
+	}
+
+	return filepath.Join(home, ".mender-clirc")
+}
+
+// maybePersistServer persists c.server to the config file if it was
+// explicitly passed via --server and differs from the default server. Any
+// error encountered while persisting is logged but not returned, since the
+// login itself has already succeeded by the time this is called.
+func (c *LoginCmd) maybePersistServer() {
+	if !c.serverChanged || c.server == defaultServerURL {
+		return
+	}
+
+	path := resolveConfigFilePath(viper.ConfigFileUsed(), os.UserHomeDir)
+	written, err := persistServerToConfig(path, c.server)
+	if err != nil {
+		log.Errf("failed to persist server to config file %s: %s", path, err)
+		return
+	}
+
+	if written {
+		log.Infof("saved server=%s to config file %s", c.server, path)
+	} else {
+		log.Infof("Warning: config file %s already has a server configured, "+
+			"not overriding it with %s", path, c.server)
+	}
+}

--- a/cmd/login_config_test.go
+++ b/cmd/login_config_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPersistServerToConfigCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	written, err := persistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true for a new file")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat created file: %s", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("expected file mode 0600, got %o", perm)
+	}
+
+	content := readJSONFile(t, path)
+	if len(content) != 1 {
+		t.Errorf("expected 1 key, got %d: %v", len(content), content)
+	}
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigCreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", ".mender-clirc")
+
+	written, err := persistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true for a new file")
+	}
+
+	content := readJSONFile(t, path)
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigAddsServerPreservingExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"username": "alice", "password": "secret"}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := persistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true when server key was absent")
+	}
+
+	content := readJSONFile(t, path)
+	if len(content) != 3 {
+		t.Errorf("expected 3 keys, got %d: %v", len(content), content)
+	}
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+	if content["username"] != "alice" {
+		t.Errorf("expected username=alice, got %v", content["username"])
+	}
+	if content["password"] != "secret" {
+		t.Errorf("expected password=secret, got %v", content["password"])
+	}
+}
+
+func TestPersistServerToConfigDoesNotOverwriteExistingServerKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"server": "https://staging.example.com", "username": "bob"}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := persistServerToConfig(path, "https://different.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if written {
+		t.Fatal("expected written=false when server key already exists")
+	}
+
+	content := readJSONFile(t, path)
+	if content["server"] != "https://staging.example.com" {
+		t.Errorf("expected server to remain unchanged, got %v", content["server"])
+	}
+	if content["username"] != "bob" {
+		t.Errorf("expected username=bob, got %v", content["username"])
+	}
+}
+
+func TestPersistServerToConfigEmptyStringServerKeyCountsAsSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"server": ""}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := persistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if written {
+		t.Fatal("expected written=false when server key is present (even if empty)")
+	}
+
+	content := readJSONFile(t, path)
+	if content["server"] != "" {
+		t.Errorf("expected server to remain empty, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{not valid json`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	_, err := persistServerToConfig(path, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %s", err)
+	}
+	if string(data) != string(original) {
+		t.Errorf("expected file to remain unchanged, got %q", string(data))
+	}
+}
+
+func TestResolveConfigFilePath(t *testing.T) {
+	homeErr := errors.New("no home dir")
+
+	cases := []struct {
+		name     string
+		used     string
+		homeDir  string
+		homeErr  error
+		wantPath string
+	}{
+		{
+			name:     "viper config file used is returned as-is",
+			used:     "/etc/mender-cli/.mender-clirc",
+			homeDir:  "/home/someone",
+			wantPath: "/etc/mender-cli/.mender-clirc",
+		},
+		{
+			name:     "falls back to home dir when no config file used",
+			used:     "",
+			homeDir:  "/home/someone",
+			wantPath: filepath.Join("/home/someone", ".mender-clirc"),
+		},
+		{
+			name:     "falls back to relative path when home dir errors",
+			used:     "",
+			homeErr:  homeErr,
+			wantPath: ".mender-clirc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			homeDirFunc := func() (string, error) {
+				if tc.homeErr != nil {
+					return "", tc.homeErr
+				}
+				return tc.homeDir, nil
+			}
+
+			got := resolveConfigFilePath(tc.used, homeDirFunc)
+			if got != tc.wantPath {
+				t.Errorf("resolveConfigFilePath(%q, ...) = %q, want %q", tc.used, got, tc.wantPath)
+			}
+		})
+	}
+}
+
+func readJSONFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %s", path, err)
+	}
+
+	var content map[string]interface{}
+	if err := json.Unmarshal(data, &content); err != nil {
+		t.Fatalf("failed to parse JSON file %s: %s", path, err)
+	}
+
+	return content
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,8 @@ const (
 	argRootVerbose    = "verbose"
 	argRootGenerate   = "generate-autocomplete"
 	argRootVersion    = "version"
+
+	defaultServerURL = "https://hosted.mender.io"
 )
 
 func init() {
@@ -120,7 +122,7 @@ func init() {
 		StringP(
 			argRootServer,
 			"",
-			"https://hosted.mender.io",
+			defaultServerURL,
 			"root server URL, e.g. 'https://hosted.mender.io'",
 		)
 	_ = viper.BindPFlag(argRootServer, rootCmd.PersistentFlags().Lookup(argRootServer))


### PR DESCRIPTION
After a successful login with an explicit --server pointing to something different than hosted.mender.io, create or update .mender-clirc for further commands to use.