### PR TITLE
fix: exit terminal session when device connection is lost

### DIFF
--- a/cmd/terminal.go
+++ b/cmd/terminal.go
@@ -424,7 +424,8 @@ func (c *TerminalCmd) runLoop(
 			err := client.WriteMessage(msg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				break
+				c.err = errors.New("connection with the device lost")
+				c.running = false
 			}
 		case healthcheckInterval := <-c.healthcheck:
 			healthcheckTimeout = time.Now().Add(time.Duration(healthcheckInterval) * time.Second)
@@ -527,9 +528,9 @@ func (c *TerminalCmd) pipeStdout(
 		if err != nil {
 			if c.running {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			} else {
-				c.Stop()
+				c.err = errors.New("connection with the device lost")
 			}
+			c.Stop()
 			break
 		}
 		if m.Header.Proto == ws.ProtoTypeShell &&


### PR DESCRIPTION
## What

When the websocket connection to the device dies (e.g. after a period of inactivity), `mender-cli terminal` gets stuck in an error loop instead of exiting.

## Why

In `runLoop`, the write-error branch used `break`, which in Go only exits the `select` statement — not the `for` loop. So after the connection drops, every keypress goes stdin → msgChan → failed websocket write, printing:

```
error: Unable to write the message: write tcp 192.168.x.x:...->...:443: write: broken pipe
```

…forever. And because the local terminal is in raw mode, `CTRL+C` is not delivered as SIGINT — it is forwarded as a byte into the dead socket, producing the same error again. The only ways out are `CTRL+]` (easy to miss, the hint scrolls away at session start) or killing the process from another terminal.

## How

- `runLoop`: on a websocket write error, set `running = false` (and `c.err`) instead of `break`, so the session ends.
- `pipeStdout`: when the websocket read fails while the session is running, call `c.Stop()` so the client exits on its own as soon as the connection drops — the read side is the first place a dead connection is detected, giving ssh-like auto-exit without waiting for a keypress.

The deferred `term.Restore` then puts the local terminal back into cooked mode as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)