### PR TITLE
ci: drop codecov.yml so the org config applies

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-    patch:
-      default:
-        target: auto


### PR DESCRIPTION
The file only set `target: auto` for project and patch, which is the Codecov default anyway

apply the org-wide [Global YAML](https://app.codecov.io/account/gh/mendersoftware/yaml) **only to repositories without a repo-level `codecov.yml`** 

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ